### PR TITLE
feat(export): auto-fallback to Photos.app for iCloud-only originals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.3 (2026-05-01)
+
+- **feat(export):** automatic iCloud download fallback. When an original isn't on disk, the export now retries via Photos.app/AppleScript (`use_photos_export=True`) — same behavior as opening the photo in Photos, which downloads it on demand. Previously these photos were always skipped with "original not downloaded from iCloud" even when the user had iCloud connectivity.
+- Subprocess timeout for `export` raised from 5 minutes to 30 minutes to accommodate large iCloud download batches.
+- Skip reason on the unrecoverable case now reads `"original not downloaded from iCloud (download attempt returned no files)"` so it's distinguishable from the no-attempt skip.
+
 ## 0.1.1 (2026-04-30)
 
 - **fix(query):** parse `fromDate` / `toDate` as ISO 8601 datetimes — osxphotos requires real `datetime` objects, not strings, so date filters previously crashed with an opaque "Command failed" error.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Or, if you cloned the repo, run `npm run setup` to create a project-local Python
 | **Live Photos** | Optionally include the live-photo video alongside the still |
 | **Raw Files** | Optionally include the raw (NEF, CR2, etc.) sidecar |
 | **Multi-photo Export** | Export multiple UUIDs in a single call |
+| **Auto iCloud Download** | If an original isn't on disk, export falls back to Photos.app to download it on demand — no extra parameter needed |
 
 ### Diagnostics
 
@@ -302,6 +303,8 @@ Export one or more photos by UUID to a destination directory.
 
 **Returns:** Destination path, count of files exported, count skipped, list of exported file paths, and any errors per UUID.
 
+**iCloud-only originals:** If a photo's original isn't on disk (Photos is using "Optimize Mac Storage"), the export automatically falls back to Photos.app via AppleScript, which downloads the original on demand — same behavior as opening the photo in Photos. This is slower than a direct file copy; expect waits proportional to download size for large batches. Photos that genuinely can't be exported (e.g. `edited=true` requested but no edits exist) are still skipped with a per-UUID reason.
+
 ---
 
 ## Usage Patterns
@@ -441,7 +444,7 @@ This is the same pattern used by [apple-numbers-mcp](https://github.com/sweetrb/
 | macOS only | Apple Photos and osxphotos are macOS-specific |
 | Read-only | osxphotos reads the Photos library; this server does not modify it |
 | Full Disk Access required | The Photos library SQLite database is in a protected directory |
-| No iCloud-only photos | Photos that exist only in iCloud (not downloaded) report `isMissing: true` and can't be exported |
+| iCloud-only export is slower | Originals that aren't on disk are downloaded on demand via Photos.app/AppleScript. The export still succeeds, but takes longer than a local copy and requires Photos.app to be installed and signed in to iCloud |
 | Photos.app may lock the library | If Photos.app is mid-write, opening the library can fail; close Photos.app and retry |
 | Person filter requires named faces | osxphotos cannot filter by unnamed/unrecognized faces |
 
@@ -462,7 +465,9 @@ This is the same pattern used by [apple-numbers-mcp](https://github.com/sweetrb/
 - The photo may have been deleted from the library.
 
 ### Exports skip files with "missing"
-- The photo exists in iCloud but is not downloaded locally. Open the photo in Photos.app to trigger a download, then retry.
+- Since 0.1.3, the export auto-downloads iCloud-only originals via Photos.app, so this skip should be rare. If it still happens:
+  - **"original not downloaded from iCloud (download attempt returned no files)"** — Photos.app couldn't fetch it. Check iCloud connectivity, that you're signed in, and that the photo isn't excluded by a Photos sync setting.
+  - **"no edited version exists"** / **"no raw sidecar exists"** — `edited=true` or `raw=true` was requested but the photo doesn't have one. Retry without that flag.
 
 ### Photos.app errors when running
 - Closing Photos.app may resolve database-lock errors. osxphotos opens the library in read-only mode but still requires that no writer holds an exclusive lock.

--- a/src/__tests__/photosManager.test.ts
+++ b/src/__tests__/photosManager.test.ts
@@ -148,6 +148,21 @@ describe("PhotosManager", () => {
         error: "original not downloaded from iCloud",
       });
     });
+
+    it("uses a 30-minute subprocess timeout to allow on-demand iCloud downloads", () => {
+      runMock.mockReturnValue({
+        data: {
+          destination: "/tmp/out",
+          exportedCount: 1,
+          skippedCount: 0,
+          exported: ["a.jpg"],
+          skipped: [],
+        },
+      });
+      manager.exportPhotos(["A"], "/tmp/out");
+      const [, , timeout] = runMock.mock.calls[0];
+      expect(timeout).toBe(30 * 60 * 1000);
+    });
   });
 
   describe("listKeywords", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,7 +235,10 @@ server.tool(
   "export",
   "Export one or more photos (by UUID) to a destination directory. " +
     "By default exports the original. Use edited=true to export the edited version, " +
-    "live=true to include the live-photo video, raw=true to include the raw image.",
+    "live=true to include the live-photo video, raw=true to include the raw image. " +
+    "If an original isn't on disk (iCloud-only), the export falls back to Photos.app " +
+    "to download it on demand — same behavior as opening the photo in Photos. " +
+    "This can be slow for large batches; expect waits proportional to download size.",
   {
     ...libraryArg,
     uuid: z.array(z.string()).min(1).describe("Photo UUID(s) to export"),

--- a/src/services/photosManager.ts
+++ b/src/services/photosManager.ts
@@ -143,7 +143,9 @@ export class PhotosManager {
     if (options.raw) args.push("--raw");
     if (options.overwrite) args.push("--overwrite");
 
-    // Allow longer timeout for export — many large files may move bytes.
-    return this.run<ExportResult>("export", args, 5 * 60 * 1000);
+    // Generous timeout: when originals aren't on disk we fall back to
+    // Photos.app/AppleScript, which downloads from iCloud on demand. A batch
+    // of missing photos can move serious bytes.
+    return this.run<ExportResult>("export", args, 30 * 60 * 1000);
   }
 }

--- a/src/utils/photos_reader.py
+++ b/src/utils/photos_reader.py
@@ -291,30 +291,54 @@ def cmd_export(args):
 
     exported: list[str] = []
     skipped: list[dict] = []
+
+    def _do_export(p, use_photos_export: bool):
+        return p.export(
+            str(dest),
+            edited=args.edited,
+            live_photo=args.live,
+            raw_photo=args.raw,
+            overwrite=args.overwrite,
+            use_photos_export=use_photos_export,
+            timeout=300 if use_photos_export else 120,
+        )
+
+    def _unrecoverable_reason(p):
+        # Reasons retrying via Photos.app cannot fix.
+        if args.edited and not p.hasadjustments:
+            return "no edited version exists"
+        if args.raw and not p.path_raw:
+            return "no raw sidecar exists"
+        return None
+
     for p in matches:
         try:
-            paths = p.export(
-                str(dest),
-                edited=args.edited,
-                live_photo=args.live,
-                raw_photo=args.raw,
-                overwrite=args.overwrite,
-                use_photos_export=False,
-            )
+            paths = _do_export(p, use_photos_export=False)
+            if not paths:
+                unrecoverable = _unrecoverable_reason(p)
+                if unrecoverable:
+                    skipped.append({"uuid": p.uuid, "error": unrecoverable})
+                    continue
+                # Original isn't on disk (iCloud-only). Fall back to Photos.app
+                # via AppleScript, which downloads the original on demand —
+                # same behavior as opening the photo in Photos.
+                try:
+                    paths = _do_export(p, use_photos_export=True)
+                except Exception as exc:  # noqa: BLE001
+                    skipped.append(
+                        {"uuid": p.uuid, "error": f"iCloud download failed: {exc}"}
+                    )
+                    continue
+
             if paths:
                 exported.extend(paths)
             else:
-                # osxphotos returns an empty list (not an exception) when
-                # the original isn't downloaded locally. Surface that as a skip.
-                if p.ismissing or not p.path:
-                    reason = "original not downloaded from iCloud"
-                elif args.edited and not p.hasadjustments:
-                    reason = "no edited version exists"
-                elif args.raw and not p.path_raw:
-                    reason = "no raw sidecar exists"
-                else:
-                    reason = "export returned no files"
-                skipped.append({"uuid": p.uuid, "error": reason})
+                skipped.append(
+                    {
+                        "uuid": p.uuid,
+                        "error": "original not downloaded from iCloud (download attempt returned no files)",
+                    }
+                )
         except Exception as exc:  # noqa: BLE001 - report any export failure
             skipped.append({"uuid": p.uuid, "error": str(exc)})
 


### PR DESCRIPTION
## Summary

- The export tool now auto-downloads iCloud-only originals on demand via Photos.app/AppleScript (`use_photos_export=True`), same behavior as opening the photo in Photos.
- Previously these were always skipped with `original not downloaded from iCloud` even when iCloud connectivity was fine.
- Skip reasons that retrying can't fix (`no edited version exists`, `no raw sidecar exists`) short-circuit before the fallback.
- Subprocess timeout bumped 5min → 30min to accommodate large download batches.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (17 passing, +1 new test for the bumped timeout)
- [x] Live test against a previously-skipped iCloud-only ProRAW DNG: 13MB downloaded and exported successfully.
- [x] Local-only photos still take the fast `use_photos_export=False` path (no behavior change).