### PR TITLE
docs: refresh README tagline to match capabilities and repo one-liner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Documentation
+- Refreshed the README tagline to reflect the full query/search/export/inspect capabilities, matching the GitHub repo one-liner and `package.json` description.
 - Added `docs/NODE-RUNTIME-AND-TCC-PERMISSIONS.md`: why macOS re-prompts for Full Disk Access / Automation when the server runs under an ad-hoc-signed (e.g. Homebrew) Node, and the fix — run it under the official Developer-ID-signed Node so the grant survives Node updates. README and CLAUDE.md now point at it.
 
 ## [0.3.0] (2026-06-20)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apple Photos MCP Server
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that enables AI assistants like Claude to query and export from the macOS Apple Photos library, backed by the [osxphotos](https://github.com/RhetTbull/osxphotos) library.
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that enables AI assistants like Claude to query, search, export, and inspect the macOS Apple Photos library, backed by the [osxphotos](https://github.com/RhetTbull/osxphotos) library.
 
 [![npm version](https://img.shields.io/npm/v/apple-photos-mcp)](https://www.npmjs.com/package/apple-photos-mcp)
 [![CI](https://github.com/sweetrb/apple-photos-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/sweetrb/apple-photos-mcp/actions/workflows/ci.yml)


### PR DESCRIPTION
The GitHub repo description and `package.json` already advertise the full capability set ("query, search, export, and inspect the macOS Photos library via osxphotos"), but the README first-paragraph tagline still understated it as "query and export".

This brings the README tagline into line — "query, search, export, and inspect the macOS Apple Photos library" — with the osxphotos backing-library mention intact, and records the change under `## [Unreleased]` → `### Documentation` in the CHANGELOG.

Docs only; no `src/` changes. `format:check`, tests, and build all green.