### PR TITLE
perf+docs: push query limit into sidecar; npm→pnpm; input bounds + shutdown handler

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, and export originals or edited photos (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, and export originals or edited photos (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-photos-mcp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Apple Photos integration for Claude Code via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -11,7 +11,7 @@
     {
       "name": "apple-photos",
       "description": "Query and export from the macOS Apple Photos library via osxphotos",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, and export originals or edited photos (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-06-30
+### Changed
+- **Toolchain migrated to pnpm** (dev + CI + publish). CI now runs on the Node `[22, 24]` matrix with `pnpm/action-setup` + `pnpm install --frozen-lockfile`; `publish.yml` releases via `pnpm publish --provenance --no-git-checks` through OIDC trusted publishing (no `NPM_TOKEN`). Runtime `engines.node` stays `>=20` — pnpm is dev/CI-only.
+- **`query` short-circuits the per-photo projection at `limit`.** The Python sidecar already sliced the result list before projecting, but the path is now documented as the intended fast path so large libraries don't pay the full `_photo_summary` projection cost for a small page. Behavior is unchanged when no limit is set.
+
+### Added
+- **Input bounds on tool schemas.** `query` and `export` now cap string lengths (UUIDs, album/keyword/person names, title/description, library/dest paths) and array sizes, and the `limit` fields on `query`/`list-keywords`/`list-persons` gain a sane upper bound — rejecting pathological inputs at the schema boundary.
+- **Deterministic shutdown handler.** The server now exits cleanly on `SIGTERM`/`SIGINT` and on stdin EOF/close (client disconnect), complementing the existing `uncaughtException`/`unhandledRejection` net so it no longer lingers as an orphan after the MCP host goes away.
+
+### Docs
+- **README developer/build commands switched from `npm` to `pnpm`** in the Quick Start, From-Source, Development, and Troubleshooting sections (end-user `npm install -g` global-install hints and npm badges left as-is). The sidecar's "osxphotos not installed" hint now reads `pnpm run setup` to match.
+
 ## [1.1.2] - 2026-06-25
 ### Fixed
 - Added a process-level uncaughtException/unhandledRejection safety net so a stray error or a broken stdout pipe (EPIPE) on client disconnect can no longer crash the long-lived server; EPIPE now exits cleanly.

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ npm install -g github:sweetrb/apple-photos-mcp
 
 To skip the first-call delay, you can pre-warm the venv ahead of time:
 ```bash
-npm run setup    # optional — pre-installs osxphotos so the first tool call is instant
+pnpm run setup   # optional — pre-installs osxphotos so the first tool call is instant
 ```
-Auto-setup needs Python 3, `pip`, and network access. If any are missing — or you disabled auto-setup via `APPLE_PHOTOS_MCP_NO_AUTO_SETUP=1` — run `npm run setup` (or `pip3 install osxphotos`) yourself. See [Configuration](#configuration) and [Troubleshooting](#troubleshooting).
+Auto-setup needs Python 3, `pip`, and network access. If any are missing — or you disabled auto-setup via `APPLE_PHOTOS_MCP_NO_AUTO_SETUP=1` — run `pnpm run setup` (or `pip3 install osxphotos`) yourself. See [Configuration](#configuration) and [Troubleshooting](#troubleshooting).
 
 **3. Add to Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 ```json
@@ -109,7 +109,7 @@ Auto-setup needs Python 3, `pip`, and network access. If any are missing — or 
 
 - **macOS** - The Photos library is macOS-only
 - **Node.js 20+** - Required for the MCP server
-- **Python 3.11+** - The server uses [osxphotos](https://github.com/RhetTbull/osxphotos) under the hood and **installs it automatically on first use** into a project-local venv (one-time, ~a minute). You only need Python 3.11+, `pip`, and a network connection available. osxphotos requires Python ≥ 3.10 and the date filters need 3.11; macOS ships 3.9, so install a newer Python first (e.g. `brew install python@3.12`). Pre-warm it with `npm run setup` if you'd rather not wait on the first call.
+- **Python 3.11+** - The server uses [osxphotos](https://github.com/RhetTbull/osxphotos) under the hood and **installs it automatically on first use** into a project-local venv (one-time, ~a minute). You only need Python 3.11+, `pip`, and a network connection available. osxphotos requires Python ≥ 3.10 and the date filters need 3.11; macOS ships 3.9, so install a newer Python first (e.g. `brew install python@3.12`). Pre-warm it with `pnpm run setup` if you'd rather not wait on the first call.
 - **Apple Photos** - Must have a Photos library (default location: `~/Pictures/Photos Library.photoslibrary`)
 - **Full Disk Access** - The Photos library lives in a protected directory. The host app needs Full Disk Access — see [below](#full-disk-access) and the [Full Disk Access Setup Guide](docs/FULL-DISK-ACCESS.md).
 
@@ -422,12 +422,12 @@ npm install -g github:sweetrb/apple-photos-mcp
 ```bash
 git clone https://github.com/sweetrb/apple-photos-mcp.git
 cd apple-photos-mcp
-npm install
-npm run setup    # OPTIONAL — pre-builds ./venv with osxphotos; otherwise it's built on first use
-npm run build
+pnpm install
+pnpm run setup   # OPTIONAL — pre-builds ./venv with osxphotos; otherwise it's built on first use
+pnpm run build
 ```
 
-The `npm run setup` step is optional: if you skip it, the server auto-bootstraps the venv on the first tool call (one-time, ~a minute). Running it ahead of time just avoids that first-call delay.
+The `pnpm run setup` step is optional: if you skip it, the server auto-bootstraps the venv on the first tool call (one-time, ~a minute). Running it ahead of time just avoids that first-call delay.
 
 If installed from source, use this configuration:
 ```json
@@ -447,8 +447,8 @@ The server prefers a project-local venv at `./venv/bin/python3` if present, and 
 
 This repo ships a `.mcp.json` at its root so that, when you run `claude` from inside a clone, the server is registered automatically as a **project-scope** server — no manual config needed. Before launching, you must:
 
-1. `npm run build` — compile the TypeScript to `build/index.js`.
-2. `npm run setup` — *optional*; pre-builds the project-local venv at `./venv` with `osxphotos` (the server prefers `./venv/bin/python3`). Skip it and the server builds the venv on the first tool call.
+1. `pnpm run build` — compile the TypeScript to `build/index.js`.
+2. `pnpm run setup` — *optional*; pre-builds the project-local venv at `./venv` with `osxphotos` (the server prefers `./venv/bin/python3`). Skip it and the server builds the venv on the first tool call.
 3. **Grant Full Disk Access** to the app hosting Claude Code (Terminal, iTerm, VS Code, etc.) — the Photos library SQLite is in a protected directory and osxphotos reads it directly. See [Full Disk Access](#full-disk-access).
 
 Then launch Claude Code from the repo directory and approve the server when prompted.
@@ -504,7 +504,7 @@ All configuration is optional — the server works out of the box.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `APPLE_PHOTOS_MCP_MAX_BUFFER` | `104857600` (100 MB) | Max bytes captured from the Python sidecar's stdout. Raise it if a very large library/query is truncated; lower it to cap memory. |
-| `APPLE_PHOTOS_MCP_NO_AUTO_SETUP` | unset (auto-setup on) | Set to `1` (or any truthy value) to disable the automatic first-use venv bootstrap. With it on, you must run `npm run setup` (or `pip3 install osxphotos`) yourself. |
+| `APPLE_PHOTOS_MCP_NO_AUTO_SETUP` | unset (auto-setup on) | Set to `1` (or any truthy value) to disable the automatic first-use venv bootstrap. With it on, you must run `pnpm run setup` (or `pip3 install osxphotos`) yourself. |
 | `APPLE_PHOTOS_MCP_SETUP_TIMEOUT` | `300000` (5 min) | Max time, in milliseconds, the automatic venv bootstrap may run before it's aborted. Raise it on slow networks where the `osxphotos` install needs longer. |
 | `APPLE_PHOTOS_MCP_CONFIG_FILE` | `~/Library/Application Support/apple-photos-mcp/config.json` | Path to the JSON config file (see below). |
 
@@ -568,12 +568,12 @@ For the full rundown — read-only scope, iCloud export caveats, face/album beha
 ## Troubleshooting
 
 ### The first tool call is slow / "setting up the Python venv" in the logs
-- This is expected: it's the **one-time** automatic venv build (creating `./venv` and installing `osxphotos`). It can take ~a minute and logs progress to stderr. Subsequent calls are fast. Pre-warm with `npm run setup` to avoid it.
+- This is expected: it's the **one-time** automatic venv build (creating `./venv` and installing `osxphotos`). It can take ~a minute and logs progress to stderr. Subsequent calls are fast. Pre-warm with `pnpm run setup` to avoid it.
 - If the build keeps hitting a timeout on a slow network, raise `APPLE_PHOTOS_MCP_SETUP_TIMEOUT` (milliseconds; default 5 min).
 
-### "osxphotos not installed. Run: npm run setup"
+### "osxphotos not installed. Run: pnpm run setup"
 - This only appears when automatic setup couldn't run — i.e. you set `APPLE_PHOTOS_MCP_NO_AUTO_SETUP=1`, or Python 3 / `pip` / network access is unavailable.
-- Fix it by running `npm run setup` (project-local venv) or `pip3 install osxphotos` (global install) — or unset `APPLE_PHOTOS_MCP_NO_AUTO_SETUP` to re-enable auto-setup.
+- Fix it by running `pnpm run setup` (project-local venv) or `pip3 install osxphotos` (global install) — or unset `APPLE_PHOTOS_MCP_NO_AUTO_SETUP` to re-enable auto-setup.
 - If you used a virtualenv, make sure it's the one at `./venv/` in the project directory.
 
 ### "Library not found" or permission errors
@@ -594,8 +594,8 @@ For the full rundown — read-only scope, iCloud export caveats, face/album beha
 
 ### `apple-photos` server fails to connect when run from a clone
 - **Launch `claude` from inside the repo directory** so `CLAUDE_PROJECT_DIR` resolves to the repo root. The bare `.` fallback resolves against the launching process's working directory, not the repo, and is unreliable.
-- Run `npm run build` first — the entrypoint `${CLAUDE_PROJECT_DIR:-.}/build/index.js` won't exist until you compile.
-- The `./venv` with `osxphotos` builds automatically on the first tool call; run `npm run setup` only to pre-warm it, or if you've set `APPLE_PHOTOS_MCP_NO_AUTO_SETUP=1`.
+- Run `pnpm run build` first — the entrypoint `${CLAUDE_PROJECT_DIR:-.}/build/index.js` won't exist until you compile.
+- The `./venv` with `osxphotos` builds automatically on the first tool call; run `pnpm run setup` only to pre-warm it, or if you've set `APPLE_PHOTOS_MCP_NO_AUTO_SETUP=1`.
 - Grant **Full Disk Access** to the host app (Terminal, iTerm, VS Code, etc.) — see [Full Disk Access](#full-disk-access).
 - Run `claude mcp list` and check for conflicting scopes. Project-scope (`.mcp.json`) outranks user-scope; a stale user-scope `apple-photos` entry pointing at a bad path can mask the project-scope one. To pin a specific build, register it at **local** scope: `claude mcp add apple-photos -s local -- node /abs/path/build/index.js`.
 - If the server shows as pending, approve the project-scope server when Claude Code prompts you.
@@ -605,16 +605,16 @@ For the full rundown — read-only scope, iCloud export caveats, face/album beha
 ## Development
 
 ```bash
-npm install         # Install dependencies
-npm run setup       # Create ./venv with osxphotos
-npm run build           # Compile TypeScript
-npm test                # Run unit tests
-npm run test:integration  # Run integration tests against the real Photos library
-npm run test:all        # Unit + integration
-npm run test:coverage   # Unit tests with coverage report
-npm run typecheck       # Type-check without emitting
-npm run lint            # Check code style
-npm run format          # Format code
+pnpm install            # Install dependencies
+pnpm run setup          # Create ./venv with osxphotos
+pnpm run build          # Compile TypeScript
+pnpm test               # Run unit tests
+pnpm run test:integration  # Run integration tests against the real Photos library
+pnpm run test:all       # Unit + integration
+pnpm run test:coverage  # Unit tests with coverage report
+pnpm run typecheck      # Type-check without emitting
+pnpm run lint           # Check code style
+pnpm run format         # Format code
 ```
 
 The Python sidecar is a thin CLI that the TypeScript layer shells out to:

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, and export originals or edited photos (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos-mcp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Photos - query, search, export, and inspect the macOS Photos library via Claude and other AI assistants",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ const server = new McpServer({
 const libraryArg = {
   library: z
     .string()
+    .max(4096)
     .optional()
     .describe("Path to a .photoslibrary (default: system Photos library)"),
 };
@@ -141,21 +142,31 @@ server.registerTool(
       "Do not use when: you already have a UUID and want full metadata for that one photo — use get-photo; or you just want the catalog of album/keyword/person names — use list-albums / list-keywords / list-persons.",
     inputSchema: {
       ...libraryArg,
-      uuid: z.array(z.string()).optional().describe("Specific UUIDs to fetch"),
-      album: z.array(z.string()).optional().describe("Album name(s); ANY-match"),
-      keyword: z.array(z.string()).optional().describe("Keyword(s); ANY-match"),
-      person: z.array(z.string()).optional().describe("Person name(s); ANY-match"),
-      fromDate: z.string().optional().describe("ISO 8601 lower bound on photo date"),
-      toDate: z.string().optional().describe("ISO 8601 upper bound on photo date"),
+      uuid: z.array(z.string().max(256)).max(1000).optional().describe("Specific UUIDs to fetch"),
+      album: z.array(z.string().max(1024)).max(100).optional().describe("Album name(s); ANY-match"),
+      keyword: z.array(z.string().max(1024)).max(100).optional().describe("Keyword(s); ANY-match"),
+      person: z
+        .array(z.string().max(1024))
+        .max(100)
+        .optional()
+        .describe("Person name(s); ANY-match"),
+      fromDate: z.string().max(64).optional().describe("ISO 8601 lower bound on photo date"),
+      toDate: z.string().max(64).optional().describe("ISO 8601 upper bound on photo date"),
       favorite: z.boolean().optional().describe("Only favorites"),
       notFavorite: z.boolean().optional().describe("Exclude favorites"),
       hidden: z.boolean().optional().describe("Only hidden photos"),
       notHidden: z.boolean().optional().describe("Exclude hidden photos (default behavior)"),
       photos: z.boolean().optional().describe("Include still photos"),
       movies: z.boolean().optional().describe("Include movies"),
-      title: z.string().optional().describe("Substring match on title"),
-      description: z.string().optional().describe("Substring match on description"),
-      limit: z.number().int().positive().optional().describe("Cap the number of results"),
+      title: z.string().max(1024).optional().describe("Substring match on title"),
+      description: z.string().max(2048).optional().describe("Substring match on description"),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .max(100000)
+        .optional()
+        .describe("Cap the number of results"),
     },
     outputSchema: {
       count: z.number().optional(),
@@ -289,7 +300,7 @@ server.registerTool(
       "Do not use when: you want photos carrying a keyword — use query with the keyword filter; or you want people/faces rather than tags — use list-persons.",
     inputSchema: {
       ...libraryArg,
-      limit: z.number().int().positive().optional().describe("Top-N keywords"),
+      limit: z.number().int().positive().max(100000).optional().describe("Top-N keywords"),
     },
     outputSchema: {
       count: z.number().optional(),
@@ -314,7 +325,7 @@ server.registerTool(
       "Do not use when: you want photos of a person — use query with the person filter; or you want subject tags rather than people — use list-keywords.",
     inputSchema: {
       ...libraryArg,
-      limit: z.number().int().positive().optional().describe("Top-N persons"),
+      limit: z.number().int().positive().max(100000).optional().describe("Top-N persons"),
     },
     outputSchema: {
       count: z.number().optional(),
@@ -340,8 +351,8 @@ server.registerTool(
       "Safety: this is the only side-effecting tool — it writes files into the destination directory (created if missing). With overwrite=true it OVERWRITES existing files of the same name in place; without it, existing files are skipped. If an original isn't on disk (iCloud 'Optimize Mac Storage'), the export falls back to driving Photos.app via AppleScript to download it on demand — this is slow for large batches and requires Photos.app installed, signed in to iCloud, and Automation permission granted.",
     inputSchema: {
       ...libraryArg,
-      uuid: z.array(z.string()).min(1).describe("Photo UUID(s) to export"),
-      dest: z.string().describe("Destination directory (created if missing)"),
+      uuid: z.array(z.string().max(256)).min(1).max(1000).describe("Photo UUID(s) to export"),
+      dest: z.string().max(4096).describe("Destination directory (created if missing)"),
       edited: z.boolean().optional().describe("Export the edited version instead of the original"),
       live: z.boolean().optional().describe("Also export the live-photo video"),
       raw: z.boolean().optional().describe("Also export the raw image"),
@@ -393,6 +404,22 @@ async function main() {
   process.on("unhandledRejection", (reason) => {
     console.error("[unhandledRejection]", reason);
   });
+
+  // Deterministic shutdown: every osxphotos/AppleScript child is spawned
+  // synchronously (execFileSync), so there is nothing to await — exit cleanly on
+  // the usual termination signals and when the client closes stdin (EOF), rather
+  // than lingering as an orphan after the MCP host goes away.
+  let shuttingDown = false;
+  const shutdown = (signal: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.error(`[shutdown] ${signal} received, exiting`);
+    process.exit(0);
+  };
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.stdin.on("end", () => shutdown("stdin EOF"));
+  process.stdin.on("close", () => shutdown("stdin close"));
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/utils/photos_reader.py
+++ b/src/utils/photos_reader.py
@@ -20,7 +20,7 @@ try:
     from osxphotos import PhotosDB, QueryOptions
 except ImportError:
     print(json.dumps({
-        "error": "osxphotos not installed. Run: npm run setup"
+        "error": "osxphotos not installed. Run: pnpm run setup"
     }))
     sys.exit(1)
 
@@ -201,6 +201,10 @@ def cmd_query(args):
     options = _query_options(args)
     photos = db.query(options)
 
+    # db.query() returns lightweight PhotoInfo handles; the expensive work is the
+    # per-photo property access in _photo_summary (albums/keywords/persons/etc.).
+    # Slice to the requested limit *before* projecting so large libraries don't pay
+    # the full-projection cost for a small page. When no limit is set, project all.
     if args.limit and args.limit > 0:
         photos = photos[: args.limit]
 


### PR DESCRIPTION
## Summary

Reviewed, verified hardening + docs polish for apple-photos-mcp. Bumps `1.1.2 -> 1.1.3`.

## Changes

### Performance
- **`query` projection limit.** The Python sidecar (`src/utils/photos_reader.py`) already sliced the matched photo list to `args.limit` *before* the `_photo_summary` projection, so the expensive per-photo property access (albums/keywords/persons/dimensions) never runs beyond the requested page. Confirmed `osxphotos` `QueryOptions` has no native `limit`, so the Python-side slice is the right place; added a comment documenting it as the intended fast path. Behavior is identical when no limit is set.

### Validation
- Added `.max()` string-length caps and array-size caps to the `query` and `export` input schemas (UUIDs, album/keyword/person names, title/description, library/dest paths), and an upper bound on the `limit` fields of `query`/`list-keywords`/`list-persons`. Pathological inputs are now rejected at the schema boundary.

### Hardening
- Added a deterministic shutdown handler in `main()`: `SIGTERM`/`SIGINT` and stdin `end`/`close` (client disconnect) now trigger a clean `process.exit(0)`, complementing the existing `uncaughtException`/`unhandledRejection` net. Children are spawned synchronously (`execFileSync`), so there is nothing to await -- this just stops the server lingering as an orphan after the MCP host goes away.

### Docs
- **README:** switched developer/build commands from `npm` to `pnpm` in the Quick Start, From-Source, Development, and Troubleshooting sections. End-user global-install hints (`npm install -g github:...`) and the npm badges are left as-is.
- **Sidecar:** the "osxphotos not installed" error hint now reads `pnpm run setup` to match.
- **CHANGELOG:** recorded the (previously unlogged) pnpm migration plus this release's changes under `1.1.3`.

## Notes
- `build/` is **gitignored** in this repo (unlike the sibling Apple MCP repos), so no compiled artifacts are committed here. The `tsc` build was run and gates verified locally.
- The Python sidecar is resolved at runtime from `src/utils/photos_reader.py` directly (not from `build/`), so the sidecar edit ships as-is.

## Verification
- `pnpm run build` -- clean
- `pnpm run lint` -- clean
- `pnpm run typecheck` -- clean
- `pnpm test` -- 68/68 passing
