### PR TITLE
chore: add !build/ negation to .gitignore for consistency with siblings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 node_modules/
+
+# Build output is intentionally tracked so the marketplace plugin works
+# without an npm install step (Claude Code does not run npm install on
+# path-source plugins). Override the global ~/.gitignore entry.
+!build/
+!build/**
+
 *.js.map
 *.d.ts.map
 .env


### PR DESCRIPTION
The global ~/.gitignore has a build/ rule that shadows new build output
even after this repo removed its own build/ ignore line. Add the same
!build/ / !build/** negation (with the shared explanatory comment) that
apple-mail-mcp, apple-notes-mcp, and apple-numbers-mcp already carry, so
build/ stays reliably tracked for the path-source plugin.

Build-infra only, no shipped-code change, no version bump.
