### PR TITLE
chore(ci): pin pnpm minimumReleaseAge (document the supply-chain default)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,7 @@
 # fails with ERR_PNPM_IGNORED_BUILDS.
 allowBuilds:
   esbuild: true
+
+# Pin pnpm 11's supply-chain minimum-release-age default explicitly (1440 min = 1 day)
+# so it is documented and stable across pnpm upgrades. See https://pnpm.io/supply-chain-security.
+minimumReleaseAge: 1440


### PR DESCRIPTION
## What

Pins pnpm's supply-chain **`minimumReleaseAge`** explicitly in `pnpm-workspace.yaml`:

```yaml
minimumReleaseAge: 1440   # 1 day, in minutes
```

## Why

pnpm 11 ships with a built-in supply-chain `minimumReleaseAge` default of **1440 minutes (1 day)** — newly published versions of a dependency are held back for a day before they resolve, mitigating fast-moving compromised-release attacks. That default is implicit and could drift across pnpm upgrades. Setting it explicitly documents the policy and keeps it stable regardless of what a future pnpm version defaults to. See https://pnpm.io/supply-chain-security.

## Safety / scope

- **Config-only** — no shipped code (`src/**`, `requirements.txt`) touched, so `version-guard` is satisfied with no version bump.
- **Value = the current in-effect default (1440)**, so it re-resolves **nothing**: `pnpm-lock.yaml` is byte-identical (empty diff) — no dependency version changed.
- `pnpm install --frozen-lockfile` stays green (lockfile unchanged), and lint / typecheck / test / format:check / build all pass.
- The committed `build/index.js` bundle is unchanged (no `src` change).
