### PR TITLE
feat!: opt-in write tools behind APPLE_PHOTOS_MCP_ENABLE_WRITES (2.0.0)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,8 +7,8 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "1.5.0",
-      "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, and export originals or edited photos (macOS only).",
+      "version": "2.0.0",
+      "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
       "source": {
         "source": "local",
         "path": "."

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-photos",
-  "version": "1.5.0",
-  "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, and export originals or edited photos (macOS only).",
+  "version": "2.0.0",
+  "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
   "author": {
     "name": "Rob Sweet",
     "email": "rob@superiortech.io"

--- a/.antigravity-plugin/skills/apple-photos/SKILL.md
+++ b/.antigravity-plugin/skills/apple-photos/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: apple-photos
-description: Use this skill when the user wants to query, view, or export photos from their macOS Apple Photos library — searching by date/import-date/album/keyword/person/label/place/media-type, viewing photos inline as thumbnails, finding exact duplicates, browsing albums and folders, fetching metadata (location, dimensions, EXIF, type flags), or exporting originals/edited versions to a directory. Backed by osxphotos.
+description: Use this skill when the user wants to query, view, organize, or export photos from their macOS Apple Photos library — searching by date/import-date/album/keyword/person/label/place/media-type, viewing photos inline as thumbnails, finding exact duplicates, browsing albums and folders, fetching metadata (location, dimensions, EXIF, type flags), exporting originals/edited versions to a directory, or (when the opt-in write gate is enabled) creating albums, filing photos into albums, and setting titles/descriptions/keywords/favorites. Backed by osxphotos.
 ---
 
 # Apple Photos Skill
 
-This skill enables you to query and export photos from the macOS Apple Photos library using natural language. It is backed by the [osxphotos](https://github.com/RhetTbull/osxphotos) Python library and operates **read-only** against the Photos library — no modifications are made to the library itself, but exports write files to disk.
+This skill enables you to query, organize, and export photos from the macOS Apple Photos library using natural language. It is backed by the [osxphotos](https://github.com/RhetTbull/osxphotos) Python library and operates **read-only by default** — no modifications are made to the library itself, but exports write files to disk.
+
+**Write tools exist but are gated:** `create-album`, `add-to-album`, `remove-from-album`, `set-photo-metadata`, and `set-keywords` only work when the user has set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (in the server env or in `~/Library/Application Support/apple-photos-mcp/config.json`, then restarted the server). **Check `doctor` first** when a task needs writes — its `writes` check reports the gate state; a gated call returns the opt-in recipe to relay to the user. Even with writes enabled, **no tool can delete photos** (quarantine into an album; the user deletes in Photos.app).
 
 ## When to Use This Skill
 
@@ -17,6 +19,7 @@ Use this skill when the user:
 - Wants to list albums, folders, keywords, or detected persons
 - Needs full metadata for one photo or a batch (dimensions, location, EXIF camera data, type flags)
 - Wants to export photos (originals, edited versions, raw, or live-photo videos) to a directory
+- Wants to organize photos — create albums, file photos into albums, tag with keywords, set titles/descriptions/favorites (write tools; gated — see above)
 - Mentions Apple Photos, Photos.app, "my photos", "my photo library"
 
 ## Available Tools
@@ -24,7 +27,7 @@ Use this skill when the user:
 | Tool | Purpose |
 |------|---------|
 | `health-check` | Verify osxphotos is installed and the library can be opened |
-| `doctor` | Full diagnostic — five checks: Python interpreter version, osxphotos install, sidecar mode (persistent vs one-shot), library readability, and Full Disk Access (ok/warn/fail with advice) |
+| `doctor` | Full diagnostic — six checks: Python interpreter version, osxphotos install, sidecar mode (persistent vs one-shot), write-tools gate, library readability, and Full Disk Access (ok/warn/fail with advice) |
 | `library-info` | High-level stats: counts of photos, movies, albums, folders, keywords, persons |
 | `query` | Search the library with combinable filters (dates, import dates, albums, keywords, persons, labels, places, years, sizes, media types); `newestFirst` for the N most recent; returns photo summaries with UUIDs |
 | `get-photo` | Full metadata for one photo by UUID (location, dimensions, EXIF camera data, type flags, etc.) |
@@ -36,6 +39,11 @@ Use this skill when the user:
 | `list-keywords` | Keywords sorted by usage count (with optional top-N limit) |
 | `list-persons` | People detected by face recognition, sorted by photo count |
 | `export` | Export one or more photos by UUID to a destination directory |
+| `create-album` | *(write, gated)* Create an album, optionally nested in a folder path; idempotent (existing album returned, not duplicated) |
+| `add-to-album` | *(write, gated)* File photos into an album by UUID (1–100); idempotent, reports added/alreadyPresent/notFound |
+| `remove-from-album` | *(write, gated)* Remove photos from an album ONLY — never from the library; rebuilds the album (its UUID changes) |
+| `set-photo-metadata` | *(write, gated)* Set title/description/favorite; echoes before/after values for undo |
+| `set-keywords` | *(write, gated)* Add/remove keywords with union semantics — keywords you don't mention are preserved |
 
 ## Usage Patterns
 
@@ -99,6 +107,21 @@ User: "I want the edited versions, not the originals"
 → export with edited=true
 ```
 
+### Organize (write tools — gated; check doctor first)
+```
+User: "File this week's imports into a Trailcam album and tag them"
+→ doctor (writes check = ENABLED?)
+→ query addedInLast="7d" → UUIDs
+→ create-album name="Trailcam"          (idempotent)
+→ add-to-album album="Trailcam" uuid=[...]
+→ set-keywords per photo add=["trailcam"]   (merges — existing keywords kept)
+
+User: "Delete the duplicate copies"
+→ You CANNOT delete. Album-quarantine pattern instead:
+  find-duplicates → create-album "Duplicates — review & delete"
+  → add-to-album with each group's extras → user reviews + deletes in Photos.app
+```
+
 ## Important Guidelines
 
 1. **Two-step workflow:** Use `query` to find UUIDs, then `get-photo`/`get-photos`, `get-thumbnail`, or `export` for details/images/files. Don't ask the user for UUIDs — derive them from a search first. Prefer `get-photos` over repeated `get-photo` calls when you hold several UUIDs.
@@ -117,7 +140,9 @@ User: "I want the edited versions, not the originals"
 
 7. **macOS only.** The Photos library only exists on macOS.
 
-8. **First-run setup is automatic.** The server auto-bootstraps a Python venv with `osxphotos` on the first tool call — the venv lives inside the server package's own directory (the `npx` cache, for the plugin's `npx -y apple-photos-mcp` launch), not in the user's project. If a tool still reports "osxphotos not installed", run the `doctor` tool FIRST to diagnose why auto-setup failed — the most common cause is `python3` older than 3.11 (stock macOS ships 3.9): have the user run `brew install python@3.12`, then simply retry the tool call (the venv rebuilds automatically).
+7a. **Writes are opt-in — never assume they're available.** If a write tool returns "Write tools are disabled", relay the recipe: set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (env or config.json) and restart the server. `remove-from-album` removes album membership only (never deletes photos) and rebuilds the album — its UUID changes, so use the returned `album.uuid` (or the name) afterwards. `set-keywords` merges (union): keywords the user didn't mention are preserved. Writes drive Photos.app via AppleScript — the first write may pop a one-time macOS Automation prompt, and writes always target the library currently open in Photos.app.
+
+8. **First-run setup is automatic.** The server auto-bootstraps a Python venv with `osxphotos` on the first tool call — the venv lives inside the plugin's own clone (under `~/.claude/plugins/` for a marketplace install), not in the user's project. If a tool still reports "osxphotos not installed", run the `doctor` tool FIRST to diagnose why auto-setup failed — the most common cause is `python3` older than 3.11 (stock macOS ships 3.9): have the user run `brew install python@3.12`, then simply retry the tool call (the venv rebuilds automatically).
 
 ## Error Handling
 
@@ -130,3 +155,6 @@ User: "I want the edited versions, not the originals"
 | "No photos matched the query" | Filters too narrow — relax the criteria |
 | "Photo not found: <uuid>" | Wrong UUID, or photo deleted |
 | Permission errors during export | Destination not writable, or library locked by Photos.app |
+| "Write tools are disabled — apple-photos-mcp is read-only by default" | The opt-in gate isn't set — relay: `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (env or config.json) + server restart; confirm with `doctor` |
+| "Album not found: '…'" | Wrong album name/UUID — `list-albums` for exact names, or `create-album` |
+| Write fails with AppleScript `-1743` / "not authorized" | macOS Automation permission for Photos not granted to the host app — System Settings → Privacy & Security → Automation → (host app) → Photos |

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-photos-mcp",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "Apple Photos integration for Claude Code via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -10,8 +10,8 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "description": "Query and export from the macOS Apple Photos library via osxphotos",
-      "version": "1.5.0",
+      "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only)",
+      "version": "2.0.0",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-photos",
-  "version": "1.5.0",
-  "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, and export originals or edited photos (macOS only)",
+  "version": "2.0.0",
+  "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only)",
   "author": {
     "name": "Rob Sweet",
     "email": "rob@superiortech.io"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2.0.0] - 2026-07-10
+
+**New: opt-in write tools — the server stays read-only by default, with behavior unchanged from 1.x unless you set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1`.**
+
+This is the first release that *can* modify the Photos library, which is why it's a major version: the read-only guarantee is now an opt-in default rather than an absolute. Nothing changes for existing users — without the gate variable, every write tool returns a clear "how to enable" error and the library cannot be touched.
+
+### Added
+- **Five write tools** (gated behind `APPLE_PHOTOS_MCP_ENABLE_WRITES=1`, settable via env or the `config.json` mechanism; a restart applies it):
+  - **`create-album` `{name, folder?}`** — creates an album, optionally nested in a `/`-separated folder path (folders created as needed). Idempotent: an existing album of that name is returned with `created: false` instead of duplicating.
+  - **`add-to-album` `{album, uuid[]}`** — files photos into an album by name or UUID (1–100 UUIDs). Idempotent; returns `added` / `alreadyPresent` / `notFound` per UUID.
+  - **`remove-from-album` `{album, uuid[]}`** — removes photos from the ALBUM only, never from the library. Photos' AppleScript has no remove verb, so the album is rebuilt (its UUID changes — reported as `previousAlbumUuid` → `album.uuid`; manual sort order is lost); a call matching no members skips the rebuild entirely.
+  - **`set-photo-metadata` `{uuid, title?, description?, favorite?}`** — writes only the fields passed and echoes full before/after values so any change can be reverted.
+  - **`set-keywords` `{uuid, add?, remove?}`** — **union semantics**: reads the photo's current keywords and merges the edits, so keywords the caller doesn't mention are always preserved (never a blind replace). Echoes before/after; a no-change merge skips the write.
+- **Safety design (the core of this release):** no deletion capability of any kind (photos, albums, or folders — album-quarantine + Photos.app is the deletion path, keeping the 30-day Recently Deleted net); explicit UUIDs/names only (no "current selection", no wildcard operations); every target validated before any mutation; 100-UUID batch caps; the write tools are **always registered** and return the opt-in recipe when gated off (MCP clients cache tool lists, so hiding them would cost discoverability without adding safety); photoscript's default `killall Photos`-on-timeout retry policy is disabled — this server never kills the user's Photos.app.
+- **`doctor` gains a `writes` check** (now six checks): reports the gate state with the opt-in recipe when disabled; when enabled, verifies photoscript is importable and Photos.app is present, and explains the one-time macOS Automation prompt (deliberately not probed — probing would trigger it).
+- **Backend:** writes drive Photos.app via AppleScript through [photoscript](https://github.com/RhetTbull/photoscript) (now an explicit pinned dependency in `requirements.txt`; it was already installed as an osxphotos dependency). Writes always target the library currently open in Photos.app — the read tools' `library` parameter does not apply — and need macOS Automation permission (one-time prompt on first write).
+
+### Changed
+- **BREAKING (semantics only):** the package can no longer be described as unconditionally read-only — read-only is now the (unchanged) default rather than a hard guarantee. No API, tool, or configuration behaves differently unless `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` is set.
+- After any write, both metadata caches (the Node catalog cache and the sidecar's resident parsed library) are force-invalidated rather than trusting the `Photos.sqlite` mtime — Photos commits through SQLite WAL, so the mtime alone can lag a write and serve a stale snapshot.
+- README gains a prominent **Write tools (opt-in)** section (gate setup via env and config.json, safety design, the album-rebuild caveat); Tool Reference, SKILL.md (all three copies), CLAUDE.md, and LIMITATIONS.md updated to match.
+
 ## [1.5.0] - 2026-07-10
 ### Added
 - **`get-thumbnail` — see photos, not just metadata.** New tool returning one photo as an inline MCP **image content block** (base64 JPEG/PNG that vision-capable clients render directly) plus structured metadata (source path, dimensions, MIME type, byte size, `isDerivative`). It serves the smallest preview derivative Photos has **already generated** whose long edge meets `minSize` (default 360 px) — no export, no original-file transfer. When no derivative is big enough, a right-sized JPEG is rendered from the original via `sips` (never upscaled — raising `minSize` to read small text actually gets you more pixels); responses are capped at 8 MB. Movies get a thumbnail when Photos generated a poster-frame derivative; iCloud-only photos with no local image return a clear error suggesting `export`. Unlocks visual triage ("show me the best photo from Saturday"), duplicate eyeballing, and reading text in photos — every workflow that previously dead-ended at metadata or required export-to-disk.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,14 +4,21 @@ This file provides guidance for AI agents (Claude, etc.) when using this MCP ser
 
 ## Overview
 
-This MCP server gives AI assistants **read-only** access to the macOS Apple
-Photos library via [osxphotos](https://github.com/RhetTbull/osxphotos). All
-operations are **local** — nothing leaves the user's machine. You can query the
-library, inspect individual photos (singly or in batches, including EXIF
-camera data), **see** photos inline via thumbnails, find exact-duplicate
-groups, browse the library's structure (albums, folders, keywords, persons),
-and **export** copies of photos to a directory. You cannot modify the library
-itself.
+This MCP server gives AI assistants access to the macOS Apple Photos library
+via [osxphotos](https://github.com/RhetTbull/osxphotos) — **read-only by
+default**. All operations are **local** — nothing leaves the user's machine.
+You can query the library, inspect individual photos (singly or in batches,
+including EXIF camera data), **see** photos inline via thumbnails, find
+exact-duplicate groups, browse the library's structure (albums, folders,
+keywords, persons), and **export** copies of photos to a directory.
+
+**Write tools exist but are gated:** `create-album`, `add-to-album`,
+`remove-from-album`, `set-photo-metadata`, and `set-keywords` only work when
+the user has set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (env or config.json +
+server restart). Until then every write call returns a clear opt-in error —
+**run `doctor` first** when writes matter: its `writes` check reports the gate
+state. Even with writes enabled, **nothing can delete a photo** (see "Write
+workflow" below).
 
 ## Related Documentation
 
@@ -46,10 +53,10 @@ Run **`health-check`** first when in doubt — it confirms both at once (osxphot
 present + library openable). When something is actually broken, reach for
 **`doctor`**: it's the richest diagnostic, checking the Python interpreter
 (path + version — warns below the required 3.11), osxphotos install, the
-sidecar execution mode (persistent vs one-shot fallback), library readability,
-and Full Disk Access separately and reporting each as ok / warn / fail with an
-actionable message — so it pinpoints *which* of the first-run requirements is
-missing.
+sidecar execution mode (persistent vs one-shot fallback), the write-tools gate
+(enabled/disabled + backend readiness), library readability, and Full Disk
+Access separately and reporting each as ok / warn / fail with an actionable
+message — so it pinpoints *which* of the first-run requirements is missing.
 
 ## Performance model: cold vs warm calls
 
@@ -100,8 +107,45 @@ Two worked patterns built from these pieces:
 - **Dedupe with visual verification:** `find-duplicates` → groups of exact
   duplicates (Photos' fingerprint; identical image data only) → `get-thumbnail`
   a member or two per group to eyeball them → since this server cannot delete,
-  have the user collect the extra copies into a quarantine album in Photos.app
-  and delete there.
+  collect the extra copies into a quarantine album (writes enabled: the
+  album-quarantine pattern below; otherwise have the user do it in Photos.app)
+  and let the user delete from there.
+
+## Write workflow (gated — check `doctor` first)
+
+The write tools follow the same query-then-act shape: `query` /
+`find-duplicates` for UUIDs, then the write tool with those explicit UUIDs.
+Rules that keep writes safe and predictable:
+
+- **Check the gate before promising anything.** A write call on a read-only
+  server returns "Write tools are disabled…" with the opt-in recipe
+  (`APPLE_PHOTOS_MCP_ENABLE_WRITES=1` via env or config.json + restart) —
+  relay that recipe to the user rather than retrying. `doctor`'s `writes`
+  check reports the state up front.
+- **There is NO delete.** Deliberately: no tool deletes photos, albums, or
+  folders. The deletion UX is the **album-quarantine pattern** — file the
+  condemned photos into a clearly-named album and have the user review +
+  delete inside Photos.app (30-day Recently Deleted safety net):
+  ```
+  1. find-duplicates                        → groups with UUIDs
+  2. create-album name="Duplicates — review & delete"   (idempotent)
+  3. add-to-album with each group's EXTRA copies (keep the best per group)
+  4. tell the user to review the album in Photos.app and delete there
+  ```
+- **`remove-from-album` rebuilds the album.** Photos' AppleScript has no
+  remove verb, so removal recreates the album minus the removed photos: the
+  album **UUID changes** (response carries `previousAlbumUuid` → `album.uuid`)
+  and manual sort order is lost. It never touches the photos themselves. Use
+  the NEW uuid for follow-up calls (or just use the album name).
+- **`set-keywords` merges, never replaces.** Union semantics: existing
+  keywords the caller doesn't mention are preserved. Revert with the echoed
+  `before` list. A keyword in both `add` and `remove` is rejected.
+- **Metadata writes echo before/after** — capture `before` when the user may
+  want an undo.
+- **Writes target the library currently open in Photos.app** (normally the
+  system library); the `library` parameter applies to read tools only. Writes
+  launch Photos.app if needed and require macOS **Automation** permission —
+  the first write may pop a one-time system prompt.
 
 ## Conventions and behaviors to know
 
@@ -154,7 +198,7 @@ Two worked patterns built from these pieces:
 | Tool | Purpose |
 |------|---------|
 | `health-check` | Verify osxphotos is installed and the library opens (while another operation is running it answers immediately with a liveness summary instead of queueing behind it) |
-| `doctor` | Full setup diagnostic — Python interpreter version, osxphotos install, sidecar mode (persistent vs one-shot), library readability, and Full Disk Access, each ok/warn/fail with advice (richer than `health-check`) |
+| `doctor` | Full setup diagnostic — Python interpreter version, osxphotos install, sidecar mode (persistent vs one-shot), write-tools gate, library readability, and Full Disk Access, each ok/warn/fail with advice (richer than `health-check`) |
 | `library-info` | High-level counts (photos, movies, albums, folders, keywords, persons) |
 | `query` | Find photos by taken/import date, album, keyword, person, ML label, place, folder, year, size, media type, or flags → returns UUIDs (`newestFirst` for the N most recent) |
 | `get-photo` | Full metadata for one photo by UUID (incl. EXIF camera data) |
@@ -166,6 +210,11 @@ Two worked patterns built from these pieces:
 | `list-keywords` | Keywords sorted by usage count |
 | `list-persons` | Named people sorted by photo count |
 | `export` | Copy photo(s) by UUID to a destination directory |
+| `create-album` | *(write, gated)* Create an album, optionally in a folder path; idempotent |
+| `add-to-album` | *(write, gated)* File photos into an album by UUID; idempotent, per-UUID report |
+| `remove-from-album` | *(write, gated)* Remove photos from an album ONLY (never the library); rebuilds the album — UUID changes |
+| `set-photo-metadata` | *(write, gated)* Set title/description/favorite; echoes before/after for undo |
+| `set-keywords` | *(write, gated)* Add/remove keywords with union semantics — unmentioned keywords preserved |
 
 ## Error Handling
 
@@ -178,6 +227,9 @@ Two worked patterns built from these pieces:
 | Export skipped: "Photo does not have adjustments..." / "raw component not on disk..." | `edited` requested but the photo has no edits / `raw` requested but the raw file isn't downloaded | Retry without that flag |
 | Export skipped: "already exists at destination" | A file with that name is already at `dest` and `overwrite` wasn't set | Pass `overwrite: true` to replace, or export to a fresh directory |
 | Export skipped: "UUID not found (deleted or in trash)" | Stale UUID — photo deleted or moved to Recently Deleted since the query | Re-run `query` to get current UUIDs |
+| "Write tools are disabled — apple-photos-mcp is read-only by default" | The `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` opt-in isn't set | Relay the opt-in recipe (env or config.json + server restart); confirm with `doctor`'s `writes` check |
+| "Album not found: '…'" | Wrong album name/UUID, or the album lives in a different library than the one open in Photos.app | `list-albums` for exact names; `create-album` to create it |
+| Write fails with AppleScript error `-1743` / "not authorized" | macOS Automation permission for Photos not granted (or denied) to the host app | Re-enable under System Settings → Privacy & Security → Automation → (host app) → Photos; first write from a GUI session triggers the one-time prompt |
 | "Operation timed out after 60000ms" | Very large library — the first (cold) call after startup, an idle period, or a library change parses the whole Photos DB | Set `APPLE_PHOTOS_MCP_TIMEOUT` (ms) higher; warm calls are then fast |
 | "Export destination ... is outside the allowed export roots" | `dest` resolves outside home, `/tmp`, `/private/tmp`, and `/Volumes` (symlinks are followed) | Pick a destination under one of those roots |
 | Database-lock error | Photos.app is mid-write | Close Photos.app and retry (queries only — iCloud export needs Photos) |
@@ -194,6 +246,9 @@ Two worked patterns built from these pieces:
 - "Do I have duplicates?" → `find-duplicates`, then `get-thumbnail` to verify visually
 - "Export those" → `export` with the UUIDs and a `dest`
 - "What albums / keywords / people are there?" → `list-albums` / `list-keywords` / `list-persons`
+- "File these into an album" → *(writes gated)* `create-album` then `add-to-album` with the UUIDs
+- "Tag / caption / favorite these" → *(writes gated)* `set-keywords` (union merge) / `set-photo-metadata`
+- "Delete the duplicates" → cannot delete: album-quarantine pattern (`create-album` + `add-to-album`), user deletes in Photos.app
 
 ## Recurring macOS permission prompts → offer the official-Node fix
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apple Photos MCP Server
 
-A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that enables AI assistants like Claude to query, search, export, and inspect the macOS Apple Photos library, backed by the [osxphotos](https://github.com/RhetTbull/osxphotos) library.
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that enables AI assistants like Claude to query, search, export, and inspect the macOS Apple Photos library — plus opt-in album and metadata write tools — backed by the [osxphotos](https://github.com/RhetTbull/osxphotos) library.
 
 [![npm version](https://img.shields.io/npm/v/apple-photos-mcp)](https://www.npmjs.com/package/apple-photos-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/apple-photos-mcp)](https://www.npmjs.com/package/apple-photos-mcp)
@@ -15,7 +15,7 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that e
   <img src="https://raw.githubusercontent.com/sweetrb/apple-photos-mcp/main/codex/assets/screenshot.png" alt="Apple Photos MCP — search, browse, and export the macOS Photos library from Codex, Claude, and other AI assistants" width="680">
 </p>
 
-> **Read-only against the Photos library.** Exports write files to a directory you choose, but the library itself is never modified.
+> **Read-only by default.** Out of the box the library is never modified — exports write files to a directory you choose, nothing more. A set of **opt-in [write tools](#write-tools-opt-in)** (albums, titles, descriptions, keywords, favorites — never deletion) unlocks only when you explicitly set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1`; without that flag, 2.x behaves exactly like the read-only 1.x releases.
 
 ## What is This?
 
@@ -29,6 +29,7 @@ This server acts as a bridge between AI assistants and Apple Photos. Once config
 - "Do I have duplicate photos?" (`find-duplicates` groups exact duplicates)
 - "List my albums"
 - "Tell me everything about photo UUID ABC-123" — including EXIF camera data
+- With [writes enabled](#write-tools-opt-in): "File these into a Trailcam album", "Tag them all `deer`", "Favorite the best one and caption it"
 
 The AI assistant communicates with this server, which uses [osxphotos](https://github.com/RhetTbull/osxphotos) to read the Photos library SQLite database directly. All data stays local on your machine.
 
@@ -155,12 +156,24 @@ Auto-setup needs Python 3, `pip`, and network access. If any are missing — or 
 | **Multi-photo Export** | Export multiple UUIDs in a single call |
 | **Auto iCloud Download** | If an original isn't on disk, export falls back to Photos.app to download it on demand — no extra parameter needed |
 
+### Write tools (opt-in — read-only by default)
+
+| Feature | Description |
+|---------|-------------|
+| **Create Album** | `create-album` creates an album (optionally nested in a folder path); idempotent — an existing album of that name is returned instead of duplicated |
+| **Add to Album** | `add-to-album` files photos (by UUID) into an album; idempotent, reports added / already-present / not-found per UUID |
+| **Remove from Album** | `remove-from-album` takes photos out of an album — never out of the library (see [the caveats](#write-tools-opt-in)) |
+| **Set Metadata** | `set-photo-metadata` sets title / description / favorite, echoing before/after values so changes can be reverted |
+| **Set Keywords** | `set-keywords` adds/removes keywords with **union semantics** — existing keywords you don't mention are always preserved |
+
+All five are **disabled unless `APPLE_PHOTOS_MCP_ENABLE_WRITES=1`** — see [Write tools (opt-in)](#write-tools-opt-in). None of them can delete a photo.
+
 ### Diagnostics
 
 | Feature | Description |
 |---------|-------------|
 | **Health Check** | Verify osxphotos is installed and the library can be opened |
-| **Doctor** | Richer setup diagnostic — five checks: Python interpreter (path + version), osxphotos install, sidecar mode (persistent vs one-shot fallback), Photos library readability, and Full Disk Access, each reported ok / warn / fail with actionable advice |
+| **Doctor** | Richer setup diagnostic — six checks: Python interpreter (path + version), osxphotos install, sidecar mode (persistent vs one-shot fallback), the write-tools gate (enabled/disabled + backend readiness), Photos library readability, and Full Disk Access, each reported ok / warn / fail with actionable advice |
 
 Read tools also return **structured JSON** (`structuredContent`) alongside the human-readable text, so agents can consume results without parsing prose.
 
@@ -170,6 +183,39 @@ Resources expose read-only context the client can attach without a tool call:
 `photos://library`, `photos://albums`, `photos://persons`, `photos://keywords`,
 and the `photos://photo/{uuid}` template (full metadata for one photo). Prompts
 package common workflows: `find-photos`, `export-photos`, `photo-summary`.
+
+---
+
+## Write tools (opt-in)
+
+**The server is read-only by default — nothing changes for existing users.** Version 2.0.0 adds five tools that can modify the Photos library (`create-album`, `add-to-album`, `remove-from-album`, `set-photo-metadata`, `set-keywords`), and every one of them is refused with a clear error until you opt in:
+
+**Enable via environment variable** (e.g. in your MCP server config's `env` block, where the host honors it):
+
+```json
+{ "env": { "APPLE_PHOTOS_MCP_ENABLE_WRITES": "1" } }
+```
+
+**Or via the config file** (recommended for Claude Desktop, which strips `env`) — `~/Library/Application Support/apple-photos-mcp/config.json`:
+
+```json
+{
+  "APPLE_PHOTOS_MCP_ENABLE_WRITES": "1"
+}
+```
+
+Then **restart the MCP server** (restart the host app, or the conversation in hosts that spawn per-conversation servers). The `doctor` tool reports the gate state either way — run it first if a write tool returns "Write tools are disabled".
+
+The write tools stay **registered** even while disabled (MCP clients cache the tool list at startup, so hiding them would only hurt discoverability — a gated call returns the exact opt-in recipe instead).
+
+### Safety design
+
+- **No deletion, ever.** There is deliberately no tool that deletes a photo, an album, or a folder. `remove-from-album` changes album *membership* only — the photos stay in All Photos and every other album. For actual deletion, quarantine photos into an album (the [dedupe pattern](#duplicate-cleanup)) and delete inside Photos.app, where Recently Deleted gives you a 30-day safety net.
+- **Explicit targets only.** Every write takes explicit UUIDs or names — there are no "current selection" or wildcard/all-photos operations, and every target is validated to exist before anything is modified (unknown UUIDs come back as clear errors or per-UUID `notFound` lists).
+- **Bounded batches.** Album operations accept at most 100 UUIDs per call.
+- **Reversible by design.** Metadata writes echo before/after values so an agent can revert; `set-keywords` uses union semantics (read-merge-write) so keywords you don't mention are never clobbered; album adds are idempotent.
+- **The mechanism:** writes drive **Photos.app via AppleScript** (the [photoscript](https://github.com/RhetTbull/photoscript) library). Photos is launched if it isn't running, and macOS asks for **Automation permission** for the host app with a one-time system prompt on the first write. Writes always target the library **currently open in Photos.app** (normally the system library) — the `library` parameter of the read tools does not apply.
+- **One quirk to know:** Photos' AppleScript dictionary has no "remove from album" verb, so `remove-from-album` **rebuilds the album** (same name, remaining photos): the album's UUID changes (the response reports old and new) and any custom manual sort order is lost.
 
 ---
 
@@ -466,6 +512,72 @@ Export one or more photos by UUID to a destination directory.
 
 **Progress notifications:** For batch exports, the server emits one MCP progress notification per photo (`progress`/`total` plus a `message` naming the file being exported) when the client's request includes a `progressToken` — so hosts that surface progress can show a live counter instead of a silent multi-minute call. Clients that don't send a token simply get the final result, as before. (Progress requires the persistent sidecar; in the rare one-shot fallback mode the export still works but reports no intermediate progress.)
 
+### Write (opt-in — see [Write tools](#write-tools-opt-in))
+
+All five tools below require `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` and return a clear opt-in error otherwise. They drive Photos.app via AppleScript (macOS Automation permission; Photos is launched if needed), always target the library currently open in Photos.app (no `library` parameter), and can never delete photos.
+
+#### `create-album`
+
+Create an album — or return the existing one of that name (`created: false`), so re-running a filing workflow never piles up duplicates.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `name` | string | Yes | Album name (≤ 255 chars) |
+| `folder` | string | No | Folder path to nest the album under, `/`-separated for nesting (e.g. `"Trips/2026"`); folders are created as needed. (Folder names containing a literal `/` are not addressable.) |
+
+**Returns:** `album {uuid, name, path}` and `created`. Without `folder`, the idempotency check matches an album of that name anywhere in the library; with `folder`, only inside that folder.
+
+#### `add-to-album`
+
+Add photos (by UUID) to an album (by name or UUID). Idempotent — Photos albums are sets.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `album` | string | Yes | Album name or UUID (UUID-looking values try the id lookup first, then fall back to a name match) |
+| `uuid` | string[] | Yes | Photo UUID(s) to add (1–100) |
+
+**Returns:** `album {uuid, name, path}`, `addedCount`, `added`, `alreadyPresent` (members already in the album), and `notFound` (UUIDs that don't exist in the library). Fails only when the album doesn't exist or *no* requested photo exists.
+
+#### `remove-from-album`
+
+Remove photos from an album — **never from the library** (they remain in All Photos and every other album).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `album` | string | Yes | Album name or UUID |
+| `uuid` | string[] | Yes | Photo UUID(s) to remove from the album (1–100) |
+
+**Returns:** the album *after* the operation, `removedCount`, `removed`, `notInAlbum` (requested UUIDs that weren't members — harmless no-ops), `albumRecreated`, and `previousAlbumUuid`.
+
+**Album rebuild caveat:** Photos' AppleScript has no remove verb, so removal rebuilds the album (create replacement → copy the kept photos → delete the original → rename). The album's **UUID changes** (use `album.uuid` from the response) and custom manual sort order is lost. When none of the UUIDs are members, nothing is rebuilt (`albumRecreated: false`).
+
+#### `set-photo-metadata`
+
+Set a photo's title, description, and/or favorite flag. Only the fields you pass are touched.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `uuid` | string | Yes | Photo UUID |
+| `title` | string | No | New title (empty string clears it) |
+| `description` | string | No | New description (empty string clears it) |
+| `favorite` | boolean | No | Set or clear the favorite flag |
+
+**Returns:** `uuid`, `updated` (which fields were written), and full `before` / `after` values of all three fields — revert a change by writing the `before` values back.
+
+#### `set-keywords`
+
+Add and/or remove keywords on a photo with **union semantics**: the photo's current keywords are read first and the edits merged in, so keywords you don't mention are always preserved — never a blind replace.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `uuid` | string | Yes | Photo UUID |
+| `add` | string[] | No | Keywords to add (≤ 100; created in Photos if new) |
+| `remove` | string[] | No | Keywords to remove from this photo (≤ 100; exact match) |
+
+At least one of `add` / `remove` is required; a keyword in both is rejected.
+
+**Returns:** `uuid`, `before` / `after` keyword lists, `added` / `removed` (what actually changed — adding an existing keyword is a no-op), and `changed`. If the merge changes nothing, no write is performed.
+
 ---
 
 ## Usage Patterns
@@ -530,6 +642,28 @@ AI: [calls get-thumbnail on members of the first few groups to verify visually]
     "Each group is byte-identical — e.g. IMG_3588.HEIC appears twice..."
 AI: "I can't delete photos (read-only) — collect one copy of each into a
      quarantine album in Photos.app and delete from there."
+```
+
+With [writes enabled](#write-tools-opt-in), the AI can build that quarantine album itself — the **album-quarantine pattern** (deletion still happens only in Photos.app, with its 30-day Recently Deleted safety net):
+
+```
+User: "Quarantine the duplicate extras for me."
+AI: [calls create-album name="Duplicates — review & delete"]
+AI: [calls add-to-album with every group's extra copies (keeping the best of each)]
+    "312 extra copies are in 'Duplicates — review & delete'.
+     Review the album in Photos.app and delete from there."
+```
+
+### Tagging and Filing (write tools)
+
+```
+User: "Tag this week's trailcam imports and file them into the Trailcam album"
+AI: [calls query addedInLast="7d"] → UUIDs
+AI: [calls create-album name="Trailcam"]        (idempotent — returns the existing album)
+AI: [calls add-to-album album="Trailcam" uuid=[...]]
+AI: [calls set-keywords per photo, add=["trailcam"]]
+    "Filed 34 photos and tagged them 'trailcam' — existing keywords untouched
+     (set-keywords merges, never replaces)."
 ```
 
 ### Browsing Library Structure
@@ -654,6 +788,7 @@ All configuration is optional — the server works out of the box.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `APPLE_PHOTOS_MCP_ENABLE_WRITES` | unset (**read-only**) | Set to `1` to enable the [write tools](#write-tools-opt-in) (`create-album`, `add-to-album`, `remove-from-album`, `set-photo-metadata`, `set-keywords`). Until then every write tool returns a clear opt-in error and the server cannot modify the library. Restart the server after changing it. |
 | `APPLE_PHOTOS_MCP_MAX_BUFFER` | `104857600` (100 MB) | Max bytes captured from the Python sidecar's stdout. Raise it if a very large library/query is truncated; lower it to cap memory. |
 | `APPLE_PHOTOS_MCP_TIMEOUT` | `60000` (60 s) | Default per-command timeout, in milliseconds, for the Python sidecar. The first (cold) call parses the whole Photos database, and on very large libraries (100k+ photos) that load alone can exceed 60 s — raise this if tools report "Operation timed out". `export` keeps its own 30-minute window. |
 | `APPLE_PHOTOS_MCP_PERSISTENT_SIDECAR` | unset (persistent mode on) | Set to `0` (or `false`) to disable the long-lived serve-mode sidecar and spawn a fresh Python process per call (pre-1.4.0 behavior). Every call then re-pays the full library parse — only useful for debugging. |
@@ -672,9 +807,12 @@ file the host doesn't manage — `APPLE_PHOTOS_MCP_CONFIG_FILE`, or by default
 
 ```json
 {
-  "APPLE_PHOTOS_MCP_MAX_BUFFER": "209715200"
+  "APPLE_PHOTOS_MCP_MAX_BUFFER": "209715200",
+  "APPLE_PHOTOS_MCP_ENABLE_WRITES": "1"
 }
 ```
+
+(The second line opts in to the [write tools](#write-tools-opt-in) — omit it to keep the server read-only.)
 
 The server reads it at startup and merges values into the environment **without
 overriding** anything already set there (so an explicit `env` still wins). This
@@ -713,7 +851,7 @@ This is the same TS + Python-sidecar pattern used by [apple-numbers-mcp](https:/
 ## Security and Privacy
 
 - **Local only** — All operations happen locally via osxphotos. No data is sent to external servers.
-- **Read-only** against the Photos library — the library is never modified.
+- **Read-only by default** — the library is never modified unless you explicitly set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (see [Write tools (opt-in)](#write-tools-opt-in)). Even with writes enabled, the tools are limited to album membership and photo metadata — **nothing can delete a photo** — and every write requires explicit UUIDs/names (no wildcard operations).
 - **Exports write to disk** — `export` writes files to the destination directory you specify, and only into an allowlisted location: the destination must resolve (symlinks included) to a path under your home directory, `/tmp`, `/private/tmp`, or `/Volumes`. Confirm destinations before running on shared machines.
 - **No credential storage** — The server doesn't store any passwords or authentication tokens.
 
@@ -726,7 +864,11 @@ For the full rundown — read-only scope, iCloud export caveats, face/album beha
 | Limitation | Reason |
 |------------|--------|
 | macOS only | Apple Photos and osxphotos are macOS-specific |
-| Read-only | osxphotos reads the Photos library; this server does not modify it |
+| Read-only by default | osxphotos reads the Photos library directly; the [write tools](#write-tools-opt-in) are opt-in (`APPLE_PHOTOS_MCP_ENABLE_WRITES=1`) and limited to albums + metadata |
+| No photo deletion | Deliberate: no tool deletes photos, albums, or folders — quarantine into an album and delete in Photos.app |
+| `remove-from-album` rebuilds the album | Photos' AppleScript has no remove verb — the album's UUID changes and manual sort order is lost |
+| Writes target the open library | AppleScript talks to whatever library Photos.app has open — the `library` parameter applies to read tools only |
+| Writes need Automation permission | Driving Photos.app via AppleScript triggers a one-time macOS Automation prompt for the host app |
 | Full Disk Access required | The Photos library SQLite database is in a protected directory |
 | iCloud-only export is slower | Originals that aren't on disk are downloaded on demand via Photos.app/AppleScript. The export still succeeds, but takes longer than a local copy and requires Photos.app to be installed and signed in to iCloud |
 | Photos.app may lock the library | If Photos.app is mid-write, opening the library can fail; close Photos.app and retry |
@@ -760,6 +902,15 @@ For the full rundown — read-only scope, iCloud export caveats, face/album beha
   - **"original not downloaded from iCloud (download attempt returned no files)"** — Photos.app couldn't fetch it. Check iCloud connectivity, that you're signed in, and that the photo isn't excluded by a Photos sync setting.
   - **"Photo does not have adjustments..."** — `edited=true` was requested but the photo has no edited version. Retry without that flag.
   - **"raw component not on disk (Photos.app fallback cannot fetch raw originals)"** — `raw=true` was requested but the raw file isn't downloaded locally. Retry without the flag, or download the original in Photos.app first (**File → Download Originals to this Mac**).
+
+### "Write tools are disabled — apple-photos-mcp is read-only by default"
+- Working as designed: the write tools require an explicit opt-in. Set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` in the server's environment or in `~/Library/Application Support/apple-photos-mcp/config.json`, then **restart the MCP server** — see [Write tools (opt-in)](#write-tools-opt-in).
+- Run the `doctor` tool to confirm the gate state (its `writes` check reports enabled/disabled and, when enabled, whether the photoscript backend and Photos.app look usable).
+
+### Write tools fail with an AppleScript / "not authorized" error
+- The host app needs **macOS Automation permission** to control Photos.app. The first write normally triggers a one-time system prompt — click OK. If it was denied, re-enable it under **System Settings → Privacy & Security → Automation → (your host app) → Photos**, then retry.
+- In headless contexts (no GUI session) the prompt can't be shown and the write fails with error `-1743`; run the first write from a normal GUI session once to grant it.
+- Writes launch Photos.app if it isn't running — the first write after a reboot can take noticeably longer while Photos starts.
 
 ### Photos.app errors when running
 - Closing Photos.app may resolve database-lock errors. osxphotos opens the library in read-only mode but still requires that no writer holds an exclusive lock.

--- a/build/index.js
+++ b/build/index.js
@@ -21369,6 +21369,7 @@ var REPO_URL = "https://github.com/sweetrb/apple-photos-mcp";
 var REQUIREMENTS_URL = `${REPO_URL}#requirements`;
 var TROUBLESHOOTING_URL = `${REPO_URL}#troubleshooting`;
 var FDA_GUIDE_URL = `${REPO_URL}/blob/main/docs/FULL-DISK-ACCESS.md`;
+var WRITE_TOOLS_URL = `${REPO_URL}#write-tools-opt-in`;
 var FDA_REMEDIATION = `Grant Full Disk Access to the HOST app that launches this MCP server (Claude Desktop / Terminal / iTerm / VS Code \u2014 not node) in System Settings > Privacy & Security > Full Disk Access, then fully quit and relaunch that app. Run the \`doctor\` tool for a full diagnosis, or see ${FDA_GUIDE_URL}.`;
 
 // src/utils/setupLock.ts
@@ -22122,6 +22123,21 @@ async function getPythonInfo() {
     return null;
   }
 }
+async function checkPhotoscript() {
+  try {
+    const python = resolvePython();
+    const version3 = (await execFileAsync(python, [
+      "-c",
+      'import photoscript, importlib.metadata; print(importlib.metadata.version("photoscript"))'
+    ])).trim();
+    return { ok: true, message: `photoscript ${version3} available` };
+  } catch {
+    return {
+      ok: false,
+      message: `photoscript not installed. Install it with: pip3 install photoscript, or run scripts/setup.sh from a repo checkout. Run the doctor tool to diagnose, or see ${TROUBLESHOOTING_URL}`
+    };
+  }
+}
 async function checkDependencies() {
   await ensureReady();
   try {
@@ -22180,6 +22196,21 @@ function resolveExportDest(dest) {
   return resolved;
 }
 
+// src/utils/writeGate.ts
+var WRITES_ENV = "APPLE_PHOTOS_MCP_ENABLE_WRITES";
+function writesEnabled(env = process.env) {
+  const value = env[WRITES_ENV];
+  return value !== void 0 && value !== "" && value !== "0" && value.toLowerCase() !== "false";
+}
+function writesDisabledMessage() {
+  return `Write tools are disabled \u2014 apple-photos-mcp is read-only by default. To enable them, set ${WRITES_ENV}=1 in the server's environment, or add {"${WRITES_ENV}": "1"} to ~/Library/Application Support/apple-photos-mcp/config.json, then restart the MCP server. Run the doctor tool to see the gate state, or see ${WRITE_TOOLS_URL}`;
+}
+function assertWritesEnabled(env = process.env) {
+  if (!writesEnabled(env)) {
+    throw new Error(writesDisabledMessage());
+  }
+}
+
 // src/services/photosManager.ts
 function augmentPermissionError(message) {
   if (/not permitted|permission|full disk|denied|unable to open/i.test(message)) {
@@ -22207,6 +22238,8 @@ var CACHEABLE_COMMANDS = /* @__PURE__ */ new Set([
   "list-persons"
 ]);
 var MAX_CACHE_ENTRIES = 8;
+var WRITE_TIMEOUT_MS = 5 * 60 * 1e3;
+var ALBUM_REBUILD_TIMEOUT_MS = 10 * 60 * 1e3;
 function flagArg(flag, value) {
   return `${flag}=${value}`;
 }
@@ -22429,6 +22462,102 @@ var PhotosManager = class {
     if (limit !== void 0) args.push(flagArg("--limit", limit));
     return this.run("list-persons", args, void 0, library);
   }
+  // ---------------------------------------------------------------------------
+  // Write tools (opt-in, gated behind APPLE_PHOTOS_MCP_ENABLE_WRITES)
+  // ---------------------------------------------------------------------------
+  /**
+   * Shared write path: enforce the opt-in gate BEFORE anything spawns, run the
+   * sidecar write command, and force-invalidate the metadata cache afterwards.
+   *
+   * The cache clear is unconditional (finally) and deliberately does NOT trust
+   * the Photos.sqlite mtime bust: Photos commits through SQLite WAL, so the
+   * main DB file's mtime may not change until a later checkpoint — an
+   * mtime-validated hit could serve a pre-write albums list. A failed write
+   * clears too (it may have partially mutated, e.g. a remove that died
+   * mid-rebuild). The Python sidecar drops its resident PhotosDB for the same
+   * reason, so the next read re-parses. Write commands are never in
+   * CACHEABLE_COMMANDS, so nothing here can populate the cache either.
+   */
+  async runWrite(command, args, timeoutMs) {
+    assertWritesEnabled();
+    try {
+      return await this.run(command, args, timeoutMs);
+    } finally {
+      this.cache.clear();
+    }
+  }
+  /**
+   * Create an album, or return the existing album of that name
+   * (created=false). folder is a "/"-separated folder path, created as needed.
+   */
+  async createAlbum(name, folder) {
+    const args = [flagArg("--name", name)];
+    if (folder !== void 0) args.push(flagArg("--folder", folder));
+    return this.runWrite("create-album", args, WRITE_TIMEOUT_MS);
+  }
+  /** Add photos (by UUID) to an album (by name or UUID). Idempotent. */
+  async addToAlbum(album, uuids) {
+    if (uuids.length === 0) {
+      throw new Error("At least one UUID is required");
+    }
+    const args = [flagArg("--album", album)];
+    for (const uuid2 of uuids) {
+      args.push(flagArg("--uuid", uuid2));
+    }
+    return this.runWrite("add-to-album", args, WRITE_TIMEOUT_MS);
+  }
+  /**
+   * Remove photos (by UUID) from an album — never from the library. The album
+   * is rebuilt to effect the removal (its UUID changes; see the tool docs).
+   */
+  async removeFromAlbum(album, uuids) {
+    if (uuids.length === 0) {
+      throw new Error("At least one UUID is required");
+    }
+    const args = [flagArg("--album", album)];
+    for (const uuid2 of uuids) {
+      args.push(flagArg("--uuid", uuid2));
+    }
+    return this.runWrite(
+      "remove-from-album",
+      args,
+      ALBUM_REBUILD_TIMEOUT_MS
+    );
+  }
+  /** Set title / description / favorite on one photo (only the fields given). */
+  async setPhotoMetadata(uuid2, updates) {
+    const args = [flagArg("--uuid", uuid2)];
+    if (updates.title !== void 0) args.push(flagArg("--title", updates.title));
+    if (updates.description !== void 0) {
+      args.push(flagArg("--description", updates.description));
+    }
+    if (updates.favorite !== void 0) {
+      args.push(flagArg("--favorite", updates.favorite ? "true" : "false"));
+    }
+    if (args.length === 1) {
+      throw new Error("Nothing to update: pass at least one of title, description, favorite");
+    }
+    return this.runWrite("set-photo-metadata", args, WRITE_TIMEOUT_MS);
+  }
+  /**
+   * Add/remove keywords on one photo with union semantics — existing keywords
+   * not mentioned are preserved (the sidecar merges against the live list).
+   */
+  async setKeywords(uuid2, edits) {
+    const add = edits.add ?? [];
+    const remove = edits.remove ?? [];
+    if (add.length === 0 && remove.length === 0) {
+      throw new Error("Nothing to do: pass add and/or remove");
+    }
+    const args = [flagArg("--uuid", uuid2)];
+    for (const k of add) {
+      args.push(flagArg("--add", k));
+    }
+    for (const k of remove) {
+      args.push(flagArg("--remove", k));
+    }
+    return this.runWrite("set-keywords", args, WRITE_TIMEOUT_MS);
+  }
   async exportPhotos(uuids, dest, options = {}) {
     if (uuids.length === 0) {
       throw new Error("At least one UUID is required to export");
@@ -22483,6 +22612,8 @@ function withErrorHandling(handler, prefix) {
 }
 
 // src/tools/doctor.ts
+import { existsSync as existsSync3 } from "node:fs";
+var PHOTOS_APP_PATH = "/System/Applications/Photos.app";
 function looksLikePermissionError(message) {
   return /not permitted|permission|full disk|denied|unable to open/i.test(message);
 }
@@ -22549,6 +22680,29 @@ async function runDoctor(manager2) {
       name: "sidecar_mode",
       status: "warn",
       detail: `could not determine the sidecar mode: ${String(e)}`
+    });
+  }
+  try {
+    if (!writesEnabled()) {
+      checks.push({
+        name: "writes",
+        status: "ok",
+        detail: `disabled \u2014 server is read-only (the default). To enable the write tools (create-album, add-to-album, remove-from-album, set-photo-metadata, set-keywords), set ${WRITES_ENV}=1 in the server env or config.json and restart. See ${WRITE_TOOLS_URL}`
+      });
+    } else {
+      const ps = await checkPhotoscript();
+      const photosAppPresent = existsSync3(PHOTOS_APP_PATH);
+      checks.push({
+        name: "writes",
+        status: !ps.ok ? "fail" : photosAppPresent ? "ok" : "warn",
+        detail: `ENABLED \u2014 the write tools can modify this Photos library (album membership, titles, descriptions, keywords, favorites; never deleting photos). ${ps.message}; Photos.app ${photosAppPresent ? "present" : `NOT found at ${PHOTOS_APP_PATH}`}. Writes drive Photos.app via AppleScript and need macOS Automation permission for the host app \u2014 macOS asks via a one-time prompt on the first write (not verifiable here without triggering that prompt).`
+      });
+    }
+  } catch (e) {
+    checks.push({
+      name: "writes",
+      status: "warn",
+      detail: `could not determine the write-tools state: ${String(e)}`
     });
   }
   let libraryOk = false;
@@ -22707,7 +22861,7 @@ function registerResourcesAndPrompts(server2, manager2) {
 }
 
 // src/services/fileConfig.ts
-import { existsSync as existsSync3, readFileSync as readFileSync2 } from "node:fs";
+import { existsSync as existsSync4, readFileSync as readFileSync2 } from "node:fs";
 import { join as join5 } from "node:path";
 import { homedir as homedir3 } from "node:os";
 function fileConfigPath(env = process.env) {
@@ -22718,7 +22872,7 @@ function fileConfigPath(env = process.env) {
 function loadFileConfig(env = process.env, path = fileConfigPath(env)) {
   const applied = [];
   try {
-    if (!existsSync3(path)) return applied;
+    if (!existsSync4(path)) return applied;
     const parsed = JSON.parse(readFileSync2(path, "utf8"));
     if (!parsed || typeof parsed !== "object") return applied;
     for (const [k, v] of Object.entries(parsed)) {
@@ -22744,7 +22898,7 @@ var manager = new PhotosManager();
 var server = new McpServer({
   name: "apple-photos",
   version: version2,
-  description: "MCP server for Apple Photos via osxphotos. Query the Photos library by date, import date, album, keyword, person, ML label, place, year, media type (screenshot, selfie, panorama, burst, \u2026), file size, or favorite/hidden flags; list albums/folders/keywords/persons; fetch full photo metadata (location, dimensions, EXIF camera data, type flags) singly or in batches; return inline viewable thumbnails; find exact-duplicate groups; and export originals or edited versions to a directory. Read-only against the Photos library. Read tools also return structuredContent (typed JSON) alongside the text."
+  description: "MCP server for Apple Photos via osxphotos. Query the Photos library by date, import date, album, keyword, person, ML label, place, year, media type (screenshot, selfie, panorama, burst, \u2026), file size, or favorite/hidden flags; list albums/folders/keywords/persons; fetch full photo metadata (location, dimensions, EXIF camera data, type flags) singly or in batches; return inline viewable thumbnails; find exact-duplicate groups; and export originals or edited versions to a directory. Read-only against the Photos library BY DEFAULT: the write tools (create-album, add-to-album, remove-from-album, set-photo-metadata, set-keywords) only work when the user opts in with APPLE_PHOTOS_MCP_ENABLE_WRITES=1, and can never delete photos. Read tools also return structuredContent (typed JSON) alongside the text."
 });
 var libraryArg = {
   library: external_exports.string().max(4096).optional().describe("Path to a .photoslibrary (default: system Photos library)")
@@ -22773,7 +22927,7 @@ server.registerTool(
 server.registerTool(
   "doctor",
   {
-    description: "Use when: a tool returns a permission or 'unable to open' error, or you want a full setup diagnostic before querying or exporting.\nReturns: five checks \u2014 Python interpreter (path + version; warns below 3.11), osxphotos install, sidecar mode (persistent vs one-shot, plus last respawn), Photos library readability, and Full Disk Access \u2014 each reported ok/warn/fail with actionable advice.\nDo not use when: you only need the lightweight is-it-working smoke test \u2014 use health-check instead.",
+    description: "Use when: a tool returns a permission, 'unable to open', or 'write tools are disabled' error, or you want a full setup diagnostic before querying, exporting, or writing.\nReturns: six checks \u2014 Python interpreter (path + version; warns below 3.11), osxphotos install, sidecar mode (persistent vs one-shot, plus last respawn), the write-tools gate (enabled/disabled, with the opt-in recipe and \u2014 when enabled \u2014 whether the photoscript backend and Photos.app look usable), Photos library readability, and Full Disk Access \u2014 each reported ok/warn/fail with actionable advice.\nDo not use when: you only need the lightweight is-it-working smoke test \u2014 use health-check instead.",
     inputSchema: {},
     outputSchema: {
       healthy: external_exports.boolean().optional(),
@@ -23048,7 +23202,7 @@ server.registerTool(
 server.registerTool(
   "find-duplicates",
   {
-    description: "Use when: you want to find exact duplicates across the library \u2014 cleaning up after a double import, checking whether files were re-uploaded, or auditing before a migration/export.\nReturns: groupCount (total duplicate groups found), returned (groups in this response, capped at limit, default 100), and groups ordered newest-first \u2014 each with the member UUIDs plus per-member filename, date, size, dimensions, and movie flag. Use get-thumbnail on members to eyeball a group before acting on it.\nDo not use when: you're looking for near-duplicates or similar shots \u2014 Photos' fingerprint matches EXACT duplicates (identical image data) only; edited copies, resized versions, and burst siblings will NOT group.\nSafety: read-only. This server cannot delete photos (Photos exposes no scriptable delete) \u2014 to act on duplicates, collect them into a quarantine album in Photos.app and review/delete there.",
+    description: "Use when: you want to find exact duplicates across the library \u2014 cleaning up after a double import, checking whether files were re-uploaded, or auditing before a migration/export.\nReturns: groupCount (total duplicate groups found), returned (groups in this response, capped at limit, default 100), and groups ordered newest-first \u2014 each with the member UUIDs plus per-member filename, date, size, dimensions, and movie flag. Use get-thumbnail on members to eyeball a group before acting on it.\nDo not use when: you're looking for near-duplicates or similar shots \u2014 Photos' fingerprint matches EXACT duplicates (identical image data) only; edited copies, resized versions, and burst siblings will NOT group.\nSafety: read-only. This server cannot delete photos \u2014 to act on duplicates, quarantine the extra copies into an album (create-album + add-to-album when writes are enabled, otherwise by hand in Photos.app) and review/delete inside Photos.app.",
     inputSchema: {
       ...libraryArg,
       limit: external_exports.number().int().positive().max(1e4).optional().describe("Max duplicate groups to return (default 100; groupCount reports the total)")
@@ -23226,6 +23380,160 @@ server.registerTool(
     }
     return successResponse(lines.join("\n"), { ...result });
   }, "export")
+);
+var writeAlbumOutput = {
+  album: external_exports.object({
+    uuid: external_exports.string().optional(),
+    name: external_exports.string().optional(),
+    path: external_exports.string().optional()
+  }).passthrough().optional()
+};
+server.registerTool(
+  "create-album",
+  {
+    description: "Use when: you need an album to file photos into \u2014 a new album by name, optionally nested inside a folder path (e.g. for a quarantine album before a dedupe review, or a per-trip album).\nReturns: album {uuid, name, path} and created \u2014 false means an album of that name already existed and was returned instead of creating a duplicate (idempotent: safe to re-run; without folder the name is matched anywhere in the library, with folder only inside that folder).\nDo not use when: you want to list existing albums \u2014 use list-albums; or you want to put photos into the album \u2014 follow up with add-to-album.\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Only creates albums/folders; never deletes, moves, or modifies photos. Drives Photos.app via AppleScript: Photos is launched if not running, and macOS Automation permission is required (one-time system prompt on first write). Writes always target the library currently open in Photos.app \u2014 there is no library parameter.",
+    inputSchema: {
+      name: external_exports.string().min(1).max(255).describe("Album name"),
+      folder: external_exports.string().min(1).max(1024).optional().describe(
+        'Folder path to nest the album under, "/"-separated for nesting (e.g. "Trips/2026"); folders are created as needed'
+      )
+    },
+    outputSchema: {
+      ...writeAlbumOutput,
+      created: external_exports.boolean().optional()
+    }
+  },
+  withErrorHandling(async ({ name, folder }) => {
+    const result = await manager.createAlbum(name, folder);
+    const verb = result.created ? "Created album" : "Album already exists";
+    return successResponse(`${verb}: ${result.album.path} (${result.album.uuid})`, {
+      ...result
+    });
+  }, "create-album")
+);
+server.registerTool(
+  "add-to-album",
+  {
+    description: "Use when: you have photo UUIDs (from query / find-duplicates) and want to file them into an album \u2014 e.g. collecting duplicate extras into a quarantine album, or filing a trip's photos.\nReturns: the album {uuid, name, path}, addedCount, added (UUIDs newly added), alreadyPresent (UUIDs that were already members \u2014 adding is idempotent), and notFound (requested UUIDs that don't exist in the library). Fails only when the album doesn't exist or NO requested photo exists.\nDo not use when: the album doesn't exist yet \u2014 call create-album first; or you want photos OUT of an album \u2014 use remove-from-album.\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Changes album membership only: photos are never copied, modified, or deleted, and each target is validated to exist first. Max 100 UUIDs per call. Drives Photos.app via AppleScript (launches it if needed; requires macOS Automation permission \u2014 one-time prompt). Writes target the library currently open in Photos.app.",
+    inputSchema: {
+      album: external_exports.string().min(1).max(1024).describe("Album name or UUID (UUID-looking values try the id lookup first)"),
+      uuid: external_exports.array(uuidSchema).min(1).max(100).describe("Photo UUID(s) to add (1\u2013100, as returned by query)")
+    },
+    outputSchema: {
+      ...writeAlbumOutput,
+      addedCount: external_exports.number().optional(),
+      added: external_exports.array(external_exports.string()).optional(),
+      alreadyPresent: external_exports.array(external_exports.string()).optional(),
+      notFound: external_exports.array(external_exports.string()).optional()
+    }
+  },
+  withErrorHandling(async ({ album, uuid: uuid2 }) => {
+    const result = await manager.addToAlbum(album, uuid2);
+    const lines = [
+      `Album:           ${result.album.path} (${result.album.uuid})`,
+      `Added:           ${result.addedCount}`
+    ];
+    if (result.alreadyPresent.length) {
+      lines.push(`Already present: ${result.alreadyPresent.length}`);
+    }
+    if (result.notFound.length) {
+      lines.push(`Not found:       ${result.notFound.join(", ")}`);
+    }
+    return successResponse(lines.join("\n"), { ...result });
+  }, "add-to-album")
+);
+server.registerTool(
+  "remove-from-album",
+  {
+    description: "Use when: you want to take photos OUT of an album \u2014 undoing a mis-filing, or clearing reviewed items from a quarantine album. This removes ALBUM MEMBERSHIP only.\nReturns: the album AFTER the operation ({uuid, name, path} \u2014 note the uuid CHANGES when anything was removed), removedCount, removed, notInAlbum (requested UUIDs that weren't members \u2014 no-ops), albumRecreated, and previousAlbumUuid.\nDo not use when: you want to delete photos from the library \u2014 this server cannot delete photos at all (quarantine them in an album and review in Photos.app instead); or the photos aren't in the album (harmless, but pointless).\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). NEVER deletes photos from the library \u2014 removed photos stay in All Photos and every other album. Photos' AppleScript has no remove-from-album verb, so the album is REBUILT (same name and remaining photos): its UUID changes and any custom manual sort order is lost; re-fetch the album UUID from the response. When none of the UUIDs are members, nothing is rebuilt. Max 100 UUIDs per call. Drives Photos.app via AppleScript (requires macOS Automation permission). Writes target the library currently open in Photos.app.",
+    inputSchema: {
+      album: external_exports.string().min(1).max(1024).describe("Album name or UUID (UUID-looking values try the id lookup first)"),
+      uuid: external_exports.array(uuidSchema).min(1).max(100).describe("Photo UUID(s) to remove from the album (1\u2013100)")
+    },
+    outputSchema: {
+      ...writeAlbumOutput,
+      removedCount: external_exports.number().optional(),
+      removed: external_exports.array(external_exports.string()).optional(),
+      notInAlbum: external_exports.array(external_exports.string()).optional(),
+      albumRecreated: external_exports.boolean().optional(),
+      previousAlbumUuid: external_exports.string().optional()
+    }
+  },
+  withErrorHandling(async ({ album, uuid: uuid2 }) => {
+    const result = await manager.removeFromAlbum(album, uuid2);
+    const lines = [
+      `Album:        ${result.album.path} (${result.album.uuid})`,
+      `Removed:      ${result.removedCount} (from the album only \u2014 photos stay in the library)`
+    ];
+    if (result.albumRecreated) {
+      lines.push(
+        `Note:         album rebuilt \u2014 its UUID changed (was ${result.previousAlbumUuid})`
+      );
+    }
+    if (result.notInAlbum.length) {
+      lines.push(`Not in album: ${result.notInAlbum.join(", ")}`);
+    }
+    return successResponse(lines.join("\n"), { ...result });
+  }, "remove-from-album")
+);
+server.registerTool(
+  "set-photo-metadata",
+  {
+    description: "Use when: you want to set a photo's title, description, or favorite flag \u2014 captioning passes, marking the best shot of a burst, titling scans.\nReturns: uuid, updated (which fields were written), and the full before/after values of all three fields \u2014 so any change can be reverted by writing the before values back.\nDo not use when: you want keywords \u2014 use set-keywords (it has union semantics; this tool doesn't touch keywords); or you only want to READ metadata \u2014 use get-photo.\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Metadata only \u2014 never touches the image asset, and only the fields you pass are modified (an empty string clears title/description). The target photo is validated to exist first. Drives Photos.app via AppleScript (requires macOS Automation permission). Writes target the library currently open in Photos.app.",
+    inputSchema: {
+      uuid: uuidSchema.describe("Photo UUID (hex-with-dashes, as returned by query)"),
+      title: external_exports.string().max(255).optional().describe("New title (empty string clears it)"),
+      description: external_exports.string().max(2048).optional().describe("New description (empty string clears it)"),
+      favorite: external_exports.boolean().optional().describe("Set or clear the favorite flag")
+    },
+    outputSchema: {
+      uuid: external_exports.string().optional(),
+      updated: external_exports.array(external_exports.string()).optional(),
+      before: external_exports.object({}).passthrough().optional(),
+      after: external_exports.object({}).passthrough().optional()
+    }
+  },
+  withErrorHandling(async ({ uuid: uuid2, title, description, favorite }) => {
+    const result = await manager.setPhotoMetadata(uuid2, { title, description, favorite });
+    const lines = [`Updated ${result.updated.join(", ")} on ${result.uuid}:`];
+    for (const field of result.updated) {
+      const key = field;
+      lines.push(
+        `  ${field}: ${JSON.stringify(result.before[key])} \u2192 ${JSON.stringify(result.after[key])}`
+      );
+    }
+    return successResponse(lines.join("\n"), { ...result });
+  }, "set-photo-metadata")
+);
+server.registerTool(
+  "set-keywords",
+  {
+    description: "Use when: you want to add and/or remove keywords (tags) on a photo \u2014 tagging workflows, fixing a mis-tag \u2014 without disturbing its other keywords.\nReturns: uuid, before/after keyword lists (revert by re-running with the diff inverted), added and removed (what actually changed \u2014 adding an existing keyword or removing an absent one is a no-op), and changed.\nDo not use when: you want to browse keywords \u2014 use list-keywords; or find photos by keyword \u2014 use query. A keyword passed in both add and remove is rejected.\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). UNION semantics \u2014 the photo's current keywords are read first and edits are merged in, so existing keywords you don't mention are ALWAYS preserved (never a blind replace). Metadata only \u2014 the image asset is untouched; the target photo is validated to exist first. Drives Photos.app via AppleScript (requires macOS Automation permission). Writes target the library currently open in Photos.app.",
+    inputSchema: {
+      uuid: uuidSchema.describe("Photo UUID (hex-with-dashes, as returned by query)"),
+      add: external_exports.array(external_exports.string().min(1).max(255)).max(100).optional().describe("Keywords to add (created in Photos if new)"),
+      remove: external_exports.array(external_exports.string().min(1).max(255)).max(100).optional().describe("Keywords to remove from this photo (exact match)")
+    },
+    outputSchema: {
+      uuid: external_exports.string().optional(),
+      before: external_exports.array(external_exports.string()).optional(),
+      after: external_exports.array(external_exports.string()).optional(),
+      added: external_exports.array(external_exports.string()).optional(),
+      removed: external_exports.array(external_exports.string()).optional(),
+      changed: external_exports.boolean().optional()
+    }
+  },
+  withErrorHandling(async ({ uuid: uuid2, add, remove }) => {
+    const result = await manager.setKeywords(uuid2, { add, remove });
+    const lines = [
+      `Keywords on ${result.uuid}${result.changed ? "" : " (no change needed)"}:`,
+      `  before: ${result.before.length ? result.before.join(", ") : "(none)"}`,
+      `  after:  ${result.after.length ? result.after.join(", ") : "(none)"}`
+    ];
+    if (result.added.length) lines.push(`  added:   ${result.added.join(", ")}`);
+    if (result.removed.length) lines.push(`  removed: ${result.removed.join(", ")}`);
+    return successResponse(lines.join("\n"), { ...result });
+  }, "set-keywords")
 );
 registerResourcesAndPrompts(server, manager);
 async function main() {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-photos",
-  "version": "1.5.0",
-  "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, and export originals or edited photos (macOS only).",
+  "version": "2.0.0",
+  "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
   "author": {
     "name": "Rob Sweet",
     "email": "rob@superiortech.io"

--- a/codex/skills/apple-photos/SKILL.md
+++ b/codex/skills/apple-photos/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: apple-photos
-description: Use this skill when the user wants to query, view, or export photos from their macOS Apple Photos library — searching by date/import-date/album/keyword/person/label/place/media-type, viewing photos inline as thumbnails, finding exact duplicates, browsing albums and folders, fetching metadata (location, dimensions, EXIF, type flags), or exporting originals/edited versions to a directory. Backed by osxphotos.
+description: Use this skill when the user wants to query, view, organize, or export photos from their macOS Apple Photos library — searching by date/import-date/album/keyword/person/label/place/media-type, viewing photos inline as thumbnails, finding exact duplicates, browsing albums and folders, fetching metadata (location, dimensions, EXIF, type flags), exporting originals/edited versions to a directory, or (when the opt-in write gate is enabled) creating albums, filing photos into albums, and setting titles/descriptions/keywords/favorites. Backed by osxphotos.
 ---
 
 # Apple Photos Skill
 
-This skill enables you to query and export photos from the macOS Apple Photos library using natural language. It is backed by the [osxphotos](https://github.com/RhetTbull/osxphotos) Python library and operates **read-only** against the Photos library — no modifications are made to the library itself, but exports write files to disk.
+This skill enables you to query, organize, and export photos from the macOS Apple Photos library using natural language. It is backed by the [osxphotos](https://github.com/RhetTbull/osxphotos) Python library and operates **read-only by default** — no modifications are made to the library itself, but exports write files to disk.
+
+**Write tools exist but are gated:** `create-album`, `add-to-album`, `remove-from-album`, `set-photo-metadata`, and `set-keywords` only work when the user has set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (in the server env or in `~/Library/Application Support/apple-photos-mcp/config.json`, then restarted the server). **Check `doctor` first** when a task needs writes — its `writes` check reports the gate state; a gated call returns the opt-in recipe to relay to the user. Even with writes enabled, **no tool can delete photos** (quarantine into an album; the user deletes in Photos.app).
 
 ## When to Use This Skill
 
@@ -17,6 +19,7 @@ Use this skill when the user:
 - Wants to list albums, folders, keywords, or detected persons
 - Needs full metadata for one photo or a batch (dimensions, location, EXIF camera data, type flags)
 - Wants to export photos (originals, edited versions, raw, or live-photo videos) to a directory
+- Wants to organize photos — create albums, file photos into albums, tag with keywords, set titles/descriptions/favorites (write tools; gated — see above)
 - Mentions Apple Photos, Photos.app, "my photos", "my photo library"
 
 ## Available Tools
@@ -24,7 +27,7 @@ Use this skill when the user:
 | Tool | Purpose |
 |------|---------|
 | `health-check` | Verify osxphotos is installed and the library can be opened |
-| `doctor` | Full diagnostic — five checks: Python interpreter version, osxphotos install, sidecar mode (persistent vs one-shot), library readability, and Full Disk Access (ok/warn/fail with advice) |
+| `doctor` | Full diagnostic — six checks: Python interpreter version, osxphotos install, sidecar mode (persistent vs one-shot), write-tools gate, library readability, and Full Disk Access (ok/warn/fail with advice) |
 | `library-info` | High-level stats: counts of photos, movies, albums, folders, keywords, persons |
 | `query` | Search the library with combinable filters (dates, import dates, albums, keywords, persons, labels, places, years, sizes, media types); `newestFirst` for the N most recent; returns photo summaries with UUIDs |
 | `get-photo` | Full metadata for one photo by UUID (location, dimensions, EXIF camera data, type flags, etc.) |
@@ -36,6 +39,11 @@ Use this skill when the user:
 | `list-keywords` | Keywords sorted by usage count (with optional top-N limit) |
 | `list-persons` | People detected by face recognition, sorted by photo count |
 | `export` | Export one or more photos by UUID to a destination directory |
+| `create-album` | *(write, gated)* Create an album, optionally nested in a folder path; idempotent (existing album returned, not duplicated) |
+| `add-to-album` | *(write, gated)* File photos into an album by UUID (1–100); idempotent, reports added/alreadyPresent/notFound |
+| `remove-from-album` | *(write, gated)* Remove photos from an album ONLY — never from the library; rebuilds the album (its UUID changes) |
+| `set-photo-metadata` | *(write, gated)* Set title/description/favorite; echoes before/after values for undo |
+| `set-keywords` | *(write, gated)* Add/remove keywords with union semantics — keywords you don't mention are preserved |
 
 ## Usage Patterns
 
@@ -99,6 +107,21 @@ User: "I want the edited versions, not the originals"
 → export with edited=true
 ```
 
+### Organize (write tools — gated; check doctor first)
+```
+User: "File this week's imports into a Trailcam album and tag them"
+→ doctor (writes check = ENABLED?)
+→ query addedInLast="7d" → UUIDs
+→ create-album name="Trailcam"          (idempotent)
+→ add-to-album album="Trailcam" uuid=[...]
+→ set-keywords per photo add=["trailcam"]   (merges — existing keywords kept)
+
+User: "Delete the duplicate copies"
+→ You CANNOT delete. Album-quarantine pattern instead:
+  find-duplicates → create-album "Duplicates — review & delete"
+  → add-to-album with each group's extras → user reviews + deletes in Photos.app
+```
+
 ## Important Guidelines
 
 1. **Two-step workflow:** Use `query` to find UUIDs, then `get-photo`/`get-photos`, `get-thumbnail`, or `export` for details/images/files. Don't ask the user for UUIDs — derive them from a search first. Prefer `get-photos` over repeated `get-photo` calls when you hold several UUIDs.
@@ -117,7 +140,9 @@ User: "I want the edited versions, not the originals"
 
 7. **macOS only.** The Photos library only exists on macOS.
 
-8. **First-run setup is automatic.** The server auto-bootstraps a Python venv with `osxphotos` on the first tool call — the venv lives inside the server package's own directory (the `npx` cache, for the Codex plugin's `npx -y apple-photos-mcp` launch), not in the user's project. If a tool still reports "osxphotos not installed", run the `doctor` tool FIRST to diagnose why auto-setup failed — the most common cause is `python3` older than 3.11 (stock macOS ships 3.9): have the user run `brew install python@3.12`, then simply retry the tool call (the venv rebuilds automatically).
+7a. **Writes are opt-in — never assume they're available.** If a write tool returns "Write tools are disabled", relay the recipe: set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (env or config.json) and restart the server. `remove-from-album` removes album membership only (never deletes photos) and rebuilds the album — its UUID changes, so use the returned `album.uuid` (or the name) afterwards. `set-keywords` merges (union): keywords the user didn't mention are preserved. Writes drive Photos.app via AppleScript — the first write may pop a one-time macOS Automation prompt, and writes always target the library currently open in Photos.app.
+
+8. **First-run setup is automatic.** The server auto-bootstraps a Python venv with `osxphotos` on the first tool call — the venv lives inside the plugin's own clone (under `~/.claude/plugins/` for a marketplace install), not in the user's project. If a tool still reports "osxphotos not installed", run the `doctor` tool FIRST to diagnose why auto-setup failed — the most common cause is `python3` older than 3.11 (stock macOS ships 3.9): have the user run `brew install python@3.12`, then simply retry the tool call (the venv rebuilds automatically).
 
 ## Error Handling
 
@@ -130,3 +155,6 @@ User: "I want the edited versions, not the originals"
 | "No photos matched the query" | Filters too narrow — relax the criteria |
 | "Photo not found: <uuid>" | Wrong UUID, or photo deleted |
 | Permission errors during export | Destination not writable, or library locked by Photos.app |
+| "Write tools are disabled — apple-photos-mcp is read-only by default" | The opt-in gate isn't set — relay: `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (env or config.json) + server restart; confirm with `doctor` |
+| "Album not found: '…'" | Wrong album name/UUID — `list-albums` for exact names, or `create-album` |
+| Write fails with AppleScript `-1743` / "not authorized" | macOS Automation permission for Photos not granted to the host app — System Settings → Privacy & Security → Automation → (host app) → Photos |

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,25 +1,58 @@
 # Limitations
 
-Apple Photos MCP is a **read-only** bridge to the macOS Photos library, backed by
-[osxphotos](https://github.com/RhetTbull/osxphotos). This page documents the real
-limitations — what the server cannot do and why — so they aren't re-investigated
-every release. These agree with the README's
-[Known Limitations](../README.md#known-limitations); this page adds the *why* and
-*what to do* for each.
+Apple Photos MCP is a **read-only-by-default** bridge to the macOS Photos
+library, backed by [osxphotos](https://github.com/RhetTbull/osxphotos). This
+page documents the real limitations — what the server cannot do and why — so
+they aren't re-investigated every release. These agree with the README's
+[Known Limitations](../README.md#known-limitations); this page adds the *why*
+and *what to do* for each.
 
-## Read-only — no writes back to Photos
+## Read-only by default — writes are an explicit opt-in
 
-**Why:** osxphotos reads the Photos library; this server deliberately never
-writes to it. There is no tool to create or rename albums, add or edit keywords,
-tag people, set titles/descriptions, favorite/unfavorite, or otherwise modify the
-library. The only tool that writes anything at all is `export`, and it writes
-**copies of files to a destination directory you choose** — it never touches the
-library itself.
+**Why:** osxphotos reads the Photos library; the read tools never write to it,
+and out of the box neither does anything else — the only disk writes are
+`export`'s **copies of files to a destination directory you choose**. Since
+2.0.0 a set of **write tools** exists (`create-album`, `add-to-album`,
+`remove-from-album`, `set-photo-metadata`, `set-keywords`), but every one of
+them is refused unless the user has set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` —
+see the README's [Write tools (opt-in)](../README.md#write-tools-opt-in)
+section for the gate, the setup, and the safety design.
 
-**What to do:** Use the server to find, inspect, and export. To change anything
-*inside* the library (rename an album, add a keyword, name a face), do it in
-Photos.app; the change will show up on the next query once Photos has persisted
-it.
+**What to do:** Use the server to find, inspect, and export; opt in to the
+write gate if you want it organizing albums and metadata too. To change
+anything the write tools don't cover (rename an album, name a face, edit an
+image), do it in Photos.app; the change shows up on the next query once Photos
+has persisted it.
+
+## No photo deletion — even with writes enabled
+
+**Why:** Deliberate safety design. No tool deletes photos, albums, or folders;
+`remove-from-album` changes album *membership* only (the photos stay in the
+library). An LLM-driven deletion of irreplaceable photos is an unacceptable
+failure mode, so the capability simply doesn't exist in this server.
+
+**What to do:** Use the **album-quarantine pattern**: collect the photos to
+discard into a clearly-named album (`create-album` + `add-to-album`, or by
+hand), then review and delete inside Photos.app — Recently Deleted keeps them
+recoverable for ~30 days.
+
+## Write-tool caveats (when the gate is enabled)
+
+**Why:** Writes drive **Photos.app via AppleScript** (photoscript), which has
+real constraints: (1) macOS requires **Automation permission** for the host
+app — a one-time system prompt on the first write, which can't be granted
+headlessly; (2) AppleScript talks to whatever library Photos.app has **open**,
+so writes always target that library (normally the system one) — the read
+tools' `library` parameter does not apply; (3) Photos' AppleScript dictionary
+has **no remove-from-album verb**, so `remove-from-album` rebuilds the album
+(same name, remaining photos): the album's **UUID changes** and custom manual
+sort order is lost; (4) Photos is launched if it isn't running, so the first
+write can be slow.
+
+**What to do:** Run `doctor` first — its `writes` check reports the gate state
+and backend readiness. Grant the Automation prompt once from a GUI session.
+After a `remove-from-album`, use the returned `album.uuid` (or the album name)
+for follow-up calls.
 
 ## macOS only
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "apple-photos-mcp",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "packageManager": "pnpm@11.9.0",
-  "description": "MCP server for Apple Photos - query, search, export, and inspect the macOS Photos library via Claude and other AI assistants",
+  "description": "MCP server for Apple Photos - query, search, export, and inspect the macOS Photos library via Claude and other AI assistants, plus opt-in album/metadata write tools (read-only by default)",
   "type": "module",
   "main": "build/index.js",
   "bin": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 osxphotos>=0.69.0,<0.76
+# Direct dependency of the opt-in write tools (also an osxphotos transitive
+# dep). Pinned because photos_reader.py uses its script_loader.run_script for
+# bulk album-id calls — keep the floor/ceiling in step when bumping.
+photoscript>=0.5.3,<0.6

--- a/skills/apple-photos/SKILL.md
+++ b/skills/apple-photos/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: apple-photos
-description: Use this skill when the user wants to query, view, or export photos from their macOS Apple Photos library — searching by date/import-date/album/keyword/person/label/place/media-type, viewing photos inline as thumbnails, finding exact duplicates, browsing albums and folders, fetching metadata (location, dimensions, EXIF, type flags), or exporting originals/edited versions to a directory. Backed by osxphotos.
+description: Use this skill when the user wants to query, view, organize, or export photos from their macOS Apple Photos library — searching by date/import-date/album/keyword/person/label/place/media-type, viewing photos inline as thumbnails, finding exact duplicates, browsing albums and folders, fetching metadata (location, dimensions, EXIF, type flags), exporting originals/edited versions to a directory, or (when the opt-in write gate is enabled) creating albums, filing photos into albums, and setting titles/descriptions/keywords/favorites. Backed by osxphotos.
 ---
 
 # Apple Photos Skill
 
-This skill enables you to query and export photos from the macOS Apple Photos library using natural language. It is backed by the [osxphotos](https://github.com/RhetTbull/osxphotos) Python library and operates **read-only** against the Photos library — no modifications are made to the library itself, but exports write files to disk.
+This skill enables you to query, organize, and export photos from the macOS Apple Photos library using natural language. It is backed by the [osxphotos](https://github.com/RhetTbull/osxphotos) Python library and operates **read-only by default** — no modifications are made to the library itself, but exports write files to disk.
+
+**Write tools exist but are gated:** `create-album`, `add-to-album`, `remove-from-album`, `set-photo-metadata`, and `set-keywords` only work when the user has set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (in the server env or in `~/Library/Application Support/apple-photos-mcp/config.json`, then restarted the server). **Check `doctor` first** when a task needs writes — its `writes` check reports the gate state; a gated call returns the opt-in recipe to relay to the user. Even with writes enabled, **no tool can delete photos** (quarantine into an album; the user deletes in Photos.app).
 
 ## When to Use This Skill
 
@@ -17,6 +19,7 @@ Use this skill when the user:
 - Wants to list albums, folders, keywords, or detected persons
 - Needs full metadata for one photo or a batch (dimensions, location, EXIF camera data, type flags)
 - Wants to export photos (originals, edited versions, raw, or live-photo videos) to a directory
+- Wants to organize photos — create albums, file photos into albums, tag with keywords, set titles/descriptions/favorites (write tools; gated — see above)
 - Mentions Apple Photos, Photos.app, "my photos", "my photo library"
 
 ## Available Tools
@@ -24,7 +27,7 @@ Use this skill when the user:
 | Tool | Purpose |
 |------|---------|
 | `health-check` | Verify osxphotos is installed and the library can be opened |
-| `doctor` | Full diagnostic — five checks: Python interpreter version, osxphotos install, sidecar mode (persistent vs one-shot), library readability, and Full Disk Access (ok/warn/fail with advice) |
+| `doctor` | Full diagnostic — six checks: Python interpreter version, osxphotos install, sidecar mode (persistent vs one-shot), write-tools gate, library readability, and Full Disk Access (ok/warn/fail with advice) |
 | `library-info` | High-level stats: counts of photos, movies, albums, folders, keywords, persons |
 | `query` | Search the library with combinable filters (dates, import dates, albums, keywords, persons, labels, places, years, sizes, media types); `newestFirst` for the N most recent; returns photo summaries with UUIDs |
 | `get-photo` | Full metadata for one photo by UUID (location, dimensions, EXIF camera data, type flags, etc.) |
@@ -36,6 +39,11 @@ Use this skill when the user:
 | `list-keywords` | Keywords sorted by usage count (with optional top-N limit) |
 | `list-persons` | People detected by face recognition, sorted by photo count |
 | `export` | Export one or more photos by UUID to a destination directory |
+| `create-album` | *(write, gated)* Create an album, optionally nested in a folder path; idempotent (existing album returned, not duplicated) |
+| `add-to-album` | *(write, gated)* File photos into an album by UUID (1–100); idempotent, reports added/alreadyPresent/notFound |
+| `remove-from-album` | *(write, gated)* Remove photos from an album ONLY — never from the library; rebuilds the album (its UUID changes) |
+| `set-photo-metadata` | *(write, gated)* Set title/description/favorite; echoes before/after values for undo |
+| `set-keywords` | *(write, gated)* Add/remove keywords with union semantics — keywords you don't mention are preserved |
 
 ## Usage Patterns
 
@@ -99,6 +107,21 @@ User: "I want the edited versions, not the originals"
 → export with edited=true
 ```
 
+### Organize (write tools — gated; check doctor first)
+```
+User: "File this week's imports into a Trailcam album and tag them"
+→ doctor (writes check = ENABLED?)
+→ query addedInLast="7d" → UUIDs
+→ create-album name="Trailcam"          (idempotent)
+→ add-to-album album="Trailcam" uuid=[...]
+→ set-keywords per photo add=["trailcam"]   (merges — existing keywords kept)
+
+User: "Delete the duplicate copies"
+→ You CANNOT delete. Album-quarantine pattern instead:
+  find-duplicates → create-album "Duplicates — review & delete"
+  → add-to-album with each group's extras → user reviews + deletes in Photos.app
+```
+
 ## Important Guidelines
 
 1. **Two-step workflow:** Use `query` to find UUIDs, then `get-photo`/`get-photos`, `get-thumbnail`, or `export` for details/images/files. Don't ask the user for UUIDs — derive them from a search first. Prefer `get-photos` over repeated `get-photo` calls when you hold several UUIDs.
@@ -117,6 +140,8 @@ User: "I want the edited versions, not the originals"
 
 7. **macOS only.** The Photos library only exists on macOS.
 
+7a. **Writes are opt-in — never assume they're available.** If a write tool returns "Write tools are disabled", relay the recipe: set `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (env or config.json) and restart the server. `remove-from-album` removes album membership only (never deletes photos) and rebuilds the album — its UUID changes, so use the returned `album.uuid` (or the name) afterwards. `set-keywords` merges (union): keywords the user didn't mention are preserved. Writes drive Photos.app via AppleScript — the first write may pop a one-time macOS Automation prompt, and writes always target the library currently open in Photos.app.
+
 8. **First-run setup is automatic.** The server auto-bootstraps a Python venv with `osxphotos` on the first tool call — the venv lives inside the plugin's own clone (under `~/.claude/plugins/` for a marketplace install), not in the user's project. If a tool still reports "osxphotos not installed", run the `doctor` tool FIRST to diagnose why auto-setup failed — the most common cause is `python3` older than 3.11 (stock macOS ships 3.9): have the user run `brew install python@3.12`, then simply retry the tool call (the venv rebuilds automatically).
 
 ## Error Handling
@@ -130,3 +155,6 @@ User: "I want the edited versions, not the originals"
 | "No photos matched the query" | Filters too narrow — relax the criteria |
 | "Photo not found: <uuid>" | Wrong UUID, or photo deleted |
 | Permission errors during export | Destination not writable, or library locked by Photos.app |
+| "Write tools are disabled — apple-photos-mcp is read-only by default" | The opt-in gate isn't set — relay: `APPLE_PHOTOS_MCP_ENABLE_WRITES=1` (env or config.json) + server restart; confirm with `doctor` |
+| "Album not found: '…'" | Wrong album name/UUID — `list-albums` for exact names, or `create-album` |
+| Write fails with AppleScript `-1743` / "not authorized" | macOS Automation permission for Photos not granted to the host app — System Settings → Privacy & Security → Automation → (host app) → Photos |

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -2,17 +2,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../utils/python.js", () => ({
   checkDependencies: vi.fn(),
+  checkPhotoscript: vi.fn(),
   getPythonInfo: vi.fn(),
   getSidecarInfo: vi.fn(),
   sidecarBusy: vi.fn(() => false),
 }));
 
 import { runDoctor, formatDoctorReport } from "../tools/doctor.js";
-import { checkDependencies, getPythonInfo, getSidecarInfo, sidecarBusy } from "../utils/python.js";
+import {
+  checkDependencies,
+  checkPhotoscript,
+  getPythonInfo,
+  getSidecarInfo,
+  sidecarBusy,
+} from "../utils/python.js";
 import type { PhotosManager } from "../services/photosManager.js";
 import type { LibraryInfo } from "../types.js";
 
 const checkMock = vi.mocked(checkDependencies);
+const photoscriptMock = vi.mocked(checkPhotoscript);
 const pythonInfoMock = vi.mocked(getPythonInfo);
 const sidecarInfoMock = vi.mocked(getSidecarInfo);
 const busyMock = vi.mocked(sidecarBusy);
@@ -56,6 +64,9 @@ describe("runDoctor", () => {
       path: "/repo/venv/bin/python3",
       version: "Python 3.12.4",
     });
+    photoscriptMock.mockReset();
+    photoscriptMock.mockResolvedValue({ ok: true, message: "photoscript 0.5.3 available" });
+    delete process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
   });
 
   it("reports healthy when python, osxphotos, and the library are all fine", async () => {
@@ -279,6 +290,9 @@ describe("formatDoctorReport", () => {
       path: "/repo/venv/bin/python3",
       version: "Python 3.12.4",
     });
+    photoscriptMock.mockReset();
+    photoscriptMock.mockResolvedValue({ ok: true, message: "photoscript 0.5.3 available" });
+    delete process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
   });
 
   it("renders icons and check names", async () => {
@@ -304,5 +318,82 @@ describe("formatDoctorReport", () => {
 
     expect(text).toContain("❌");
     expect(text).toContain("ISSUES FOUND");
+  });
+});
+
+describe("runDoctor writes check", () => {
+  let savedGate: string | undefined;
+
+  beforeEach(() => {
+    checkMock.mockReset();
+    checkMock.mockResolvedValue({ ok: true, message: "osxphotos 0.76.1 available" });
+    pythonInfoMock.mockReset();
+    pythonInfoMock.mockResolvedValue({
+      path: "/repo/venv/bin/python3",
+      version: "Python 3.12.4",
+    });
+    sidecarInfoMock.mockReset();
+    sidecarInfoMock.mockReturnValue(persistentInfo);
+    busyMock.mockReset();
+    busyMock.mockReturnValue(false);
+    photoscriptMock.mockReset();
+    photoscriptMock.mockResolvedValue({ ok: true, message: "photoscript 0.5.3 available" });
+    savedGate = process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
+    delete process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
+  });
+
+  afterEach(() => {
+    if (savedGate === undefined) {
+      delete process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
+    } else {
+      process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES = savedGate;
+    }
+  });
+
+  it("reports disabled (ok — the read-only default) with the opt-in recipe, without probing photoscript", async () => {
+    const report = await runDoctor(fakeManager(() => healthyLibrary));
+
+    const writes = report.checks.find((c) => c.name === "writes");
+    expect(writes?.status).toBe("ok");
+    expect(writes?.detail).toContain("read-only");
+    expect(writes?.detail).toContain("APPLE_PHOTOS_MCP_ENABLE_WRITES=1");
+    expect(writes?.detail).toContain("#write-tools-opt-in");
+    // Disabled gate → no photoscript probe spawned at all.
+    expect(photoscriptMock).not.toHaveBeenCalled();
+    expect(report.healthy).toBe(true);
+  });
+
+  it("reports ENABLED with the photoscript version and the Automation-prompt note", async () => {
+    process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES = "1";
+
+    const report = await runDoctor(fakeManager(() => healthyLibrary));
+
+    const writes = report.checks.find((c) => c.name === "writes");
+    expect(writes?.status).toBe("ok");
+    expect(writes?.detail).toContain("ENABLED");
+    expect(writes?.detail).toContain("photoscript 0.5.3");
+    expect(writes?.detail).toMatch(/Automation permission/);
+    expect(writes?.detail).toMatch(/never deleting photos/);
+  });
+
+  it("fails the writes check when the gate is enabled but photoscript is missing", async () => {
+    process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES = "1";
+    photoscriptMock.mockResolvedValue({ ok: false, message: "photoscript not installed. …" });
+
+    const report = await runDoctor(fakeManager(() => healthyLibrary));
+
+    const writes = report.checks.find((c) => c.name === "writes");
+    expect(writes?.status).toBe("fail");
+    expect(writes?.detail).toContain("photoscript not installed");
+    expect(report.healthy).toBe(false);
+  });
+
+  it("still reports the writes check while a sidecar operation is in flight (light probe)", async () => {
+    busyMock.mockReturnValue(true);
+
+    const report = await runDoctor(fakeManager(() => healthyLibrary));
+
+    expect(report.checks.find((c) => c.name === "writes")?.status).toBe("ok");
+    expect(report.checks.find((c) => c.name === "photos_library")?.status).toBe("warn");
   });
 });

--- a/src/__tests__/photosManager.test.ts
+++ b/src/__tests__/photosManager.test.ts
@@ -819,3 +819,284 @@ describe("PhotosManager", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Write tools (opt-in, gated behind APPLE_PHOTOS_MCP_ENABLE_WRITES)
+// ---------------------------------------------------------------------------
+describe("PhotosManager write tools", () => {
+  let manager: PhotosManager;
+  let savedGate: string | undefined;
+
+  beforeEach(() => {
+    manager = new PhotosManager();
+    runMock.mockReset();
+    statMock.mockReset();
+    statMock.mockImplementation(() => {
+      throw new Error("ENOENT: no such file");
+    });
+    savedGate = process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
+    process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES = "1";
+  });
+
+  afterEach(() => {
+    if (savedGate === undefined) {
+      delete process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
+    } else {
+      process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES = savedGate;
+    }
+  });
+
+  describe("the gate (writes disabled)", () => {
+    const gatedError = /read-only by default/;
+
+    beforeEach(() => {
+      delete process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
+    });
+
+    it("createAlbum is refused before anything spawns", async () => {
+      await expect(manager.createAlbum("X")).rejects.toThrow(gatedError);
+      expect(runMock).not.toHaveBeenCalled();
+    });
+
+    it("addToAlbum is refused before anything spawns", async () => {
+      await expect(manager.addToAlbum("X", ["A1B2"])).rejects.toThrow(gatedError);
+      expect(runMock).not.toHaveBeenCalled();
+    });
+
+    it("removeFromAlbum is refused before anything spawns", async () => {
+      await expect(manager.removeFromAlbum("X", ["A1B2"])).rejects.toThrow(gatedError);
+      expect(runMock).not.toHaveBeenCalled();
+    });
+
+    it("setPhotoMetadata is refused before anything spawns", async () => {
+      await expect(manager.setPhotoMetadata("A1B2", { title: "t" })).rejects.toThrow(gatedError);
+      expect(runMock).not.toHaveBeenCalled();
+    });
+
+    it("setKeywords is refused before anything spawns", async () => {
+      await expect(manager.setKeywords("A1B2", { add: ["k"] })).rejects.toThrow(gatedError);
+      expect(runMock).not.toHaveBeenCalled();
+    });
+
+    it("the gated error names the env var and the config file", async () => {
+      await expect(manager.createAlbum("X")).rejects.toThrow(/APPLE_PHOTOS_MCP_ENABLE_WRITES=1/);
+      await expect(manager.createAlbum("X")).rejects.toThrow(/config\.json/);
+    });
+
+    it("APPLE_PHOTOS_MCP_ENABLE_WRITES=0 and =false keep the gate closed", async () => {
+      process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES = "0";
+      await expect(manager.createAlbum("X")).rejects.toThrow(gatedError);
+      process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES = "false";
+      await expect(manager.createAlbum("X")).rejects.toThrow(gatedError);
+      expect(runMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("createAlbum", () => {
+    it("builds the sidecar command (name only)", async () => {
+      const data = { album: { uuid: "AL1", name: "Trailcam", path: "Trailcam" }, created: true };
+      runMock.mockResolvedValue({ data });
+      const result = await manager.createAlbum("Trailcam");
+      expect(runMock).toHaveBeenCalledWith(
+        "create-album",
+        ["--name=Trailcam"],
+        expect.any(Number),
+        undefined
+      );
+      expect(result).toEqual(data);
+    });
+
+    it("passes the folder path and handles leading-dash names via --flag=value", async () => {
+      runMock.mockResolvedValue({
+        data: {
+          album: { uuid: "AL1", name: "-Archive", path: "Trips/2026/-Archive" },
+          created: true,
+        },
+      });
+      await manager.createAlbum("-Archive", "Trips/2026");
+      expect(runMock).toHaveBeenCalledWith(
+        "create-album",
+        ["--name=-Archive", "--folder=Trips/2026"],
+        expect.any(Number),
+        undefined
+      );
+    });
+  });
+
+  describe("addToAlbum", () => {
+    it("builds one --uuid token per photo", async () => {
+      runMock.mockResolvedValue({
+        data: {
+          album: { uuid: "AL1", name: "T", path: "T" },
+          addedCount: 2,
+          added: ["U1", "U2"],
+          alreadyPresent: [],
+          notFound: [],
+        },
+      });
+      await manager.addToAlbum("Trailcam", ["U1", "U2"]);
+      expect(runMock).toHaveBeenCalledWith(
+        "add-to-album",
+        ["--album=Trailcam", "--uuid=U1", "--uuid=U2"],
+        expect.any(Number),
+        undefined
+      );
+    });
+
+    it("rejects an empty uuid batch without spawning", async () => {
+      await expect(manager.addToAlbum("Trailcam", [])).rejects.toThrow(/at least one/i);
+      expect(runMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removeFromAlbum", () => {
+    it("builds the sidecar command and returns the rebuild metadata", async () => {
+      const data = {
+        album: { uuid: "AL2", name: "T", path: "T" },
+        removedCount: 1,
+        removed: ["U1"],
+        notInAlbum: ["U9"],
+        albumRecreated: true,
+        previousAlbumUuid: "AL1",
+      };
+      runMock.mockResolvedValue({ data });
+      const result = await manager.removeFromAlbum("AL1", ["U1", "U9"]);
+      expect(runMock).toHaveBeenCalledWith(
+        "remove-from-album",
+        ["--album=AL1", "--uuid=U1", "--uuid=U9"],
+        expect.any(Number),
+        undefined
+      );
+      expect(result.albumRecreated).toBe(true);
+      expect(result.previousAlbumUuid).toBe("AL1");
+    });
+
+    it("rejects an empty uuid batch without spawning", async () => {
+      await expect(manager.removeFromAlbum("T", [])).rejects.toThrow(/at least one/i);
+      expect(runMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("setPhotoMetadata", () => {
+    it("passes only the fields provided", async () => {
+      runMock.mockResolvedValue({
+        data: {
+          uuid: "U1",
+          updated: ["title"],
+          before: { title: "", description: "", favorite: false },
+          after: { title: "New", description: "", favorite: false },
+        },
+      });
+      await manager.setPhotoMetadata("U1", { title: "New" });
+      expect(runMock).toHaveBeenCalledWith(
+        "set-photo-metadata",
+        ["--uuid=U1", "--title=New"],
+        expect.any(Number),
+        undefined
+      );
+    });
+
+    it("serializes favorite=false as --favorite=false (not omitted)", async () => {
+      runMock.mockResolvedValue({
+        data: { uuid: "U1", updated: ["favorite"], before: {}, after: {} },
+      });
+      await manager.setPhotoMetadata("U1", { favorite: false });
+      expect(runMock).toHaveBeenCalledWith(
+        "set-photo-metadata",
+        ["--uuid=U1", "--favorite=false"],
+        expect.any(Number),
+        undefined
+      );
+    });
+
+    it("passes an empty string through (clearing a title)", async () => {
+      runMock.mockResolvedValue({
+        data: { uuid: "U1", updated: ["title"], before: {}, after: {} },
+      });
+      await manager.setPhotoMetadata("U1", { title: "" });
+      expect(runMock).toHaveBeenCalledWith(
+        "set-photo-metadata",
+        ["--uuid=U1", "--title="],
+        expect.any(Number),
+        undefined
+      );
+    });
+
+    it("rejects when no field is provided, without spawning", async () => {
+      await expect(manager.setPhotoMetadata("U1", {})).rejects.toThrow(/nothing to update/i);
+      expect(runMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("setKeywords", () => {
+    it("builds --add/--remove tokens (dash-safe)", async () => {
+      runMock.mockResolvedValue({
+        data: { uuid: "U1", before: [], after: [], added: [], removed: [], changed: false },
+      });
+      await manager.setKeywords("U1", { add: ["Trailcam", "-archive"], remove: ["Reveal"] });
+      expect(runMock).toHaveBeenCalledWith(
+        "set-keywords",
+        ["--uuid=U1", "--add=Trailcam", "--add=-archive", "--remove=Reveal"],
+        expect.any(Number),
+        undefined
+      );
+    });
+
+    it("rejects when neither add nor remove is provided, without spawning", async () => {
+      await expect(manager.setKeywords("U1", {})).rejects.toThrow(/nothing to do/i);
+      expect(runMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("metadata-cache invalidation on write", () => {
+    const fakeStat = (mtimeMs: number) => ({ mtimeMs }) as unknown as ReturnType<typeof statSync>;
+    const albums = { count: 1, albums: [{ title: "Vacation" }] };
+
+    it("a successful write force-clears the catalog cache even when the DB mtime is unchanged (WAL)", async () => {
+      // Same mtime throughout — simulating Photos' WAL commit not touching
+      // Photos.sqlite. Without the force-clear, the third call would be a hit.
+      statMock.mockReturnValue(fakeStat(4242));
+      runMock.mockResolvedValue({ data: albums });
+
+      await manager.listAlbums();
+      await manager.listAlbums(); // cache hit
+      expect(runMock).toHaveBeenCalledTimes(1);
+
+      runMock.mockResolvedValueOnce({
+        data: { album: { uuid: "AL1", name: "X", path: "X" }, created: true },
+      });
+      await manager.createAlbum("X");
+
+      runMock.mockResolvedValue({ data: albums });
+      await manager.listAlbums(); // must re-spawn, NOT serve the stale cache
+      expect(runMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("a FAILED write also clears the cache (it may have partially mutated)", async () => {
+      statMock.mockReturnValue(fakeStat(4242));
+      runMock.mockResolvedValue({ data: albums });
+      await manager.listAlbums();
+      expect(runMock).toHaveBeenCalledTimes(1);
+
+      runMock.mockResolvedValueOnce({ error: "AppleScript error mid-rebuild" });
+      await expect(manager.removeFromAlbum("T", ["U1"])).rejects.toThrow(/mid-rebuild/);
+
+      runMock.mockResolvedValue({ data: albums });
+      await manager.listAlbums();
+      expect(runMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("a gated-off write does NOT clear the cache (nothing ran)", async () => {
+      statMock.mockReturnValue(fakeStat(4242));
+      runMock.mockResolvedValue({ data: albums });
+      await manager.listAlbums();
+
+      delete process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
+      await expect(manager.createAlbum("X")).rejects.toThrow(/read-only/);
+      process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES = "1";
+
+      await manager.listAlbums(); // still a cache hit
+      expect(runMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/__tests__/photosReaderWrites.test.ts
+++ b/src/__tests__/photosReaderWrites.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Hermetic tests for photos_reader.py's WRITE command logic — the gate, target
+ * validation, create-album idempotency, add/remove membership math, the
+ * remove rebuild sequence, union keyword merges, and before/after echoes.
+ *
+ * The REAL sidecar script runs one-shot under python3 with PYTHONPATH pointing
+ * at test/fixtures/pyfakes, whose fake photoscript/osxphotos/bitmath modules
+ * shadow the real ones (PYTHONPATH precedes site-packages) and log every
+ * mutation — so the actual handler code is exercised end-to-end with no
+ * Photos.app, no AppleScript, and no macOS permissions. Self-skips when no
+ * python3 is available (any >= 3.9 works; the fakes are stdlib-only).
+ */
+import { describe, expect, it, beforeAll } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const READER = resolve(__dirname, "../utils/photos_reader.py");
+const PYFAKES = resolve(__dirname, "../../test/fixtures/pyfakes");
+const VENV_PYTHON = resolve(__dirname, "../../venv/bin/python3");
+
+function pickPython(): string | null {
+  if (existsSync(VENV_PYTHON)) return VENV_PYTHON;
+  try {
+    execFileSync("python3", ["--version"], { stdio: "pipe" });
+    return "python3";
+  } catch {
+    return null;
+  }
+}
+
+let python: string | null = null;
+beforeAll(() => {
+  python = pickPython();
+});
+
+interface FakeState {
+  albums: Array<{
+    uuid: string;
+    name: string;
+    path?: string;
+    members: string[];
+    folder?: string[];
+  }>;
+  photos: Record<
+    string,
+    { title?: string; description?: string; favorite?: boolean; keywords?: string[] }
+  >;
+}
+
+const baseState = (): FakeState => ({
+  albums: [{ uuid: "A11111", name: "Trailcam", path: "Trailcam", members: ["0001", "0002"] }],
+  photos: {
+    "0001": { title: "one", description: "", favorite: false, keywords: ["Reveal", "deer"] },
+    "0002": { title: "", description: "", favorite: true, keywords: [] },
+    "0003": { title: "", description: "", favorite: false, keywords: [] },
+  },
+});
+
+interface RunResult {
+  status: number;
+  json: Record<string, unknown>;
+  log: Array<Record<string, unknown>>;
+}
+
+function runReader(
+  args: string[],
+  state: FakeState = baseState(),
+  opts: { writesEnabled?: boolean } = {}
+): RunResult {
+  const dir = mkdtempSync(join(tmpdir(), "photos-writes-test-"));
+  const statePath = join(dir, "state.json");
+  const logPath = join(dir, "log.jsonl");
+  writeFileSync(statePath, JSON.stringify(state));
+  writeFileSync(logPath, "");
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PYTHONPATH: PYFAKES,
+    FAKE_PHOTOSCRIPT_STATE: statePath,
+    FAKE_PHOTOSCRIPT_LOG: logPath,
+  };
+  delete env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
+  if (opts.writesEnabled !== false) {
+    env.APPLE_PHOTOS_MCP_ENABLE_WRITES = "1";
+  }
+
+  const proc = spawnSync(python as string, [READER, ...args], {
+    env,
+    encoding: "utf-8",
+    timeout: 30_000,
+  });
+  const stdout = (proc.stdout ?? "").trim();
+  let json: Record<string, unknown> = {};
+  try {
+    json = JSON.parse(stdout) as Record<string, unknown>;
+  } catch {
+    throw new Error(
+      `photos_reader did not print JSON (status ${proc.status}):\nstdout: ${stdout}\nstderr: ${proc.stderr}`
+    );
+  }
+  const log = readFileSync(logPath, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+  return { status: proc.status ?? -1, json, log };
+}
+
+describe("photos_reader write commands (hermetic, fake photoscript)", () => {
+  describe("the gate (defense in depth inside the sidecar)", () => {
+    it("refuses every write command when APPLE_PHOTOS_MCP_ENABLE_WRITES is unset", (ctx) => {
+      if (!python) ctx.skip();
+      for (const args of [
+        ["create-album", "--name=X"],
+        ["add-to-album", "--album=Trailcam", "--uuid=0001"],
+        ["remove-from-album", "--album=Trailcam", "--uuid=0001"],
+        ["set-photo-metadata", "--uuid=0001", "--title=t"],
+        ["set-keywords", "--uuid=0001", "--add=k"],
+      ]) {
+        const r = runReader(args, baseState(), { writesEnabled: false });
+        expect(r.status).toBe(1);
+        expect(String(r.json.error)).toMatch(/read-only by default/);
+        expect(String(r.json.error)).toContain("APPLE_PHOTOS_MCP_ENABLE_WRITES");
+        expect(r.log).toEqual([]); // nothing was mutated — nothing even ran
+      }
+    });
+
+    it("disables photoscript's killall-Photos retry policy before any write", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["create-album", "--name=Fresh"]);
+      expect(r.status).toBe(0);
+      expect(r.log[0]).toMatchObject({ op: "configure_run_script", retry_enabled: false });
+    });
+  });
+
+  describe("create-album", () => {
+    it("creates a new top-level album (created=true)", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["create-album", "--name=Fresh"]);
+      expect(r.status).toBe(0);
+      expect(r.json.created).toBe(true);
+      const album = r.json.album as Record<string, unknown>;
+      expect(album.name).toBe("Fresh");
+      expect(r.log.some((e) => e.op === "create_album")).toBe(true);
+    });
+
+    it("is idempotent: an existing name is returned with created=false and nothing is created", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["create-album", "--name=Trailcam"]);
+      expect(r.status).toBe(0);
+      expect(r.json.created).toBe(false);
+      expect((r.json.album as Record<string, unknown>).uuid).toBe("A11111");
+      expect(r.log.filter((e) => e.op === "create_album")).toEqual([]);
+    });
+
+    it("creates the folder path as needed and nests the album", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["create-album", "--name=Camping", "--folder=Trips/2026"]);
+      expect(r.status).toBe(0);
+      expect(r.json.created).toBe(true);
+      expect((r.json.album as Record<string, unknown>).path).toBe("Trips/2026/Camping");
+      expect(r.log.some((e) => e.op === "make_folders")).toBe(true);
+      const mk = r.log.find((e) => e.op === "make_folders") as { path: string[] };
+      expect(mk.path).toEqual(["Trips", "2026"]);
+    });
+  });
+
+  describe("add-to-album", () => {
+    it("splits the batch into added / alreadyPresent / notFound", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader([
+        "add-to-album",
+        "--album=Trailcam",
+        "--uuid=0002",
+        "--uuid=0003",
+        "--uuid=DEAD1",
+      ]);
+      expect(r.status).toBe(0);
+      expect(r.json.addedCount).toBe(1);
+      expect(r.json.added).toEqual(["0003"]);
+      expect(r.json.alreadyPresent).toEqual(["0002"]);
+      expect(r.json.notFound).toEqual(["DEAD1"]);
+      const add = r.log.find((e) => e.op === "album_add") as { ids: string[] };
+      expect(add.ids).toEqual(["0003"]); // only the missing one was sent to Photos
+    });
+
+    it("fails clearly when the album does not exist (validate-first)", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["add-to-album", "--album=Nope", "--uuid=0001"]);
+      expect(r.status).toBe(1);
+      expect(String(r.json.error)).toMatch(/Album not found: 'Nope'/);
+      expect(r.log.filter((e) => e.op === "album_add")).toEqual([]);
+    });
+
+    it("fails when NO requested photo exists", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["add-to-album", "--album=Trailcam", "--uuid=DEAD1", "--uuid=DEAD2"]);
+      expect(r.status).toBe(1);
+      expect(String(r.json.error)).toMatch(/None of the requested photos exist/);
+    });
+
+    it("resolves the album by UUID as well as by name", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["add-to-album", "--album=A11111", "--uuid=0003"]);
+      expect(r.status).toBe(0);
+      expect((r.json.album as Record<string, unknown>).uuid).toBe("A11111");
+    });
+  });
+
+  describe("remove-from-album", () => {
+    it("removes members by REBUILDING the album (create temp → add keepers → delete old → rename)", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["remove-from-album", "--album=Trailcam", "--uuid=0001"]);
+      expect(r.status).toBe(0);
+      expect(r.json.removedCount).toBe(1);
+      expect(r.json.removed).toEqual(["0001"]);
+      expect(r.json.albumRecreated).toBe(true);
+      expect(r.json.previousAlbumUuid).toBe("A11111");
+      const album = r.json.album as Record<string, unknown>;
+      expect(album.uuid).not.toBe("A11111"); // the rebuild changes the UUID
+      expect(album.name).toBe("Trailcam");
+
+      const ops = r.log.map((e) => e.op);
+      const seq = ops.filter((o) =>
+        ["create_album", "album_add", "delete_album", "rename_album"].includes(o as string)
+      );
+      expect(seq).toEqual(["create_album", "album_add", "delete_album", "rename_album"]);
+      const add = r.log.find((e) => e.op === "album_add") as { ids: string[] };
+      expect(add.ids).toEqual(["0002"]); // only the kept photo moved to the new album
+      const del = r.log.find((e) => e.op === "delete_album") as { uuid: string };
+      expect(del.uuid).toBe("A11111"); // the ORIGINAL album was deleted, never a photo
+    });
+
+    it("is a no-op (no rebuild, no deletion) when none of the UUIDs are members", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["remove-from-album", "--album=Trailcam", "--uuid=0003"]);
+      expect(r.status).toBe(0);
+      expect(r.json.removedCount).toBe(0);
+      expect(r.json.albumRecreated).toBe(false);
+      expect(r.json.notInAlbum).toEqual(["0003"]);
+      expect((r.json.album as Record<string, unknown>).uuid).toBe("A11111"); // unchanged
+      expect(r.log.filter((e) => e.op === "delete_album")).toEqual([]);
+      expect(r.log.filter((e) => e.op === "create_album")).toEqual([]);
+    });
+  });
+
+  describe("set-photo-metadata", () => {
+    it("writes only the fields given and echoes before/after", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader([
+        "set-photo-metadata",
+        "--uuid=0002",
+        "--title=Best shot",
+        "--favorite=false",
+      ]);
+      expect(r.status).toBe(0);
+      expect(r.json.updated).toEqual(["title", "favorite"]);
+      expect(r.json.before).toMatchObject({ title: "", favorite: true });
+      expect(r.json.after).toMatchObject({ title: "Best shot", favorite: false });
+      // description was not passed → not written
+      expect(r.log.filter((e) => e.op === "set_description")).toEqual([]);
+    });
+
+    it("fails clearly for an unknown photo (validate-first)", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["set-photo-metadata", "--uuid=DEAD1", "--title=x"]);
+      expect(r.status).toBe(1);
+      expect(String(r.json.error)).toBe("Photo not found: DEAD1");
+      expect(r.log.filter((e) => String(e.op).startsWith("set_"))).toEqual([]);
+    });
+
+    it("rejects a call with nothing to update", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["set-photo-metadata", "--uuid=0001"]);
+      expect(r.status).toBe(1);
+      expect(String(r.json.error)).toMatch(/Nothing to update/);
+    });
+  });
+
+  describe("set-keywords (union semantics)", () => {
+    it("merges add/remove into the CURRENT list — unmentioned keywords survive", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader([
+        "set-keywords",
+        "--uuid=0001",
+        "--add=Trailcam",
+        "--add=deer", // already present → no-op
+        "--remove=Reveal",
+      ]);
+      expect(r.status).toBe(0);
+      expect(r.json.before).toEqual(["Reveal", "deer"]);
+      expect(r.json.after).toEqual(["deer", "Trailcam"]); // deer preserved, never blanked
+      expect(r.json.added).toEqual(["Trailcam"]);
+      expect(r.json.removed).toEqual(["Reveal"]);
+      expect(r.json.changed).toBe(true);
+      const set = r.log.find((e) => e.op === "set_keywords") as { value: string[] };
+      expect(set.value).toEqual(["deer", "Trailcam"]);
+    });
+
+    it("skips the write entirely when the merge changes nothing", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["set-keywords", "--uuid=0001", "--add=deer", "--remove=absent"]);
+      expect(r.status).toBe(0);
+      expect(r.json.changed).toBe(false);
+      expect(r.json.after).toEqual(["Reveal", "deer"]);
+      expect(r.log.filter((e) => e.op === "set_keywords")).toEqual([]);
+    });
+
+    it("rejects a keyword passed in both add and remove", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["set-keywords", "--uuid=0001", "--add=deer", "--remove=deer"]);
+      expect(r.status).toBe(1);
+      expect(String(r.json.error)).toMatch(/both added and removed: deer/);
+    });
+
+    it("rejects a call with neither add nor remove", (ctx) => {
+      if (!python) ctx.skip();
+      const r = runReader(["set-keywords", "--uuid=0001"]);
+      expect(r.status).toBe(1);
+      expect(String(r.json.error)).toMatch(/Nothing to do/);
+    });
+  });
+});

--- a/src/__tests__/writeGate.test.ts
+++ b/src/__tests__/writeGate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  WRITES_ENV,
+  assertWritesEnabled,
+  writesDisabledMessage,
+  writesEnabled,
+} from "../utils/writeGate.js";
+
+describe("writeGate", () => {
+  describe("writesEnabled", () => {
+    it.each([
+      ["1", true],
+      ["true", true],
+      ["TRUE", true],
+      ["yes", true], // any non-falsy token opts in (mirrors isTrueish elsewhere)
+      ["0", false],
+      ["false", false],
+      ["FALSE", false],
+      ["", false],
+    ])("value %j → %s", (value, expected) => {
+      expect(writesEnabled({ [WRITES_ENV]: value })).toBe(expected);
+    });
+
+    it("is disabled when the variable is absent (the read-only default)", () => {
+      expect(writesEnabled({})).toBe(false);
+    });
+  });
+
+  describe("assertWritesEnabled", () => {
+    it("throws the gated-off message when disabled", () => {
+      expect(() => assertWritesEnabled({})).toThrow(/read-only by default/);
+      expect(() => assertWritesEnabled({})).toThrow(writesDisabledMessage());
+    });
+
+    it("does not throw when enabled", () => {
+      expect(() => assertWritesEnabled({ [WRITES_ENV]: "1" })).not.toThrow();
+    });
+  });
+
+  describe("writesDisabledMessage", () => {
+    it("tells the user exactly how to opt in (env var, config.json, restart, doctor, docs)", () => {
+      const msg = writesDisabledMessage();
+      expect(msg).toContain("APPLE_PHOTOS_MCP_ENABLE_WRITES=1");
+      expect(msg).toContain("config.json");
+      expect(msg).toMatch(/restart/i);
+      expect(msg).toMatch(/doctor/);
+      expect(msg).toContain("https://github.com/sweetrb/apple-photos-mcp#write-tools-opt-in");
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,11 @@ const server = new McpServer({
     "albums/folders/keywords/persons; fetch full photo metadata (location, dimensions, " +
     "EXIF camera data, type flags) singly or in batches; return inline viewable " +
     "thumbnails; find exact-duplicate groups; and export originals or edited versions to " +
-    "a directory. Read-only against the Photos library. Read tools also return " +
-    "structuredContent (typed JSON) alongside the text.",
+    "a directory. Read-only against the Photos library BY DEFAULT: the write tools " +
+    "(create-album, add-to-album, remove-from-album, set-photo-metadata, set-keywords) " +
+    "only work when the user opts in with APPLE_PHOTOS_MCP_ENABLE_WRITES=1, and can " +
+    "never delete photos. Read tools also return structuredContent (typed JSON) " +
+    "alongside the text.",
 });
 
 const libraryArg = {
@@ -83,8 +86,8 @@ server.registerTool(
   "doctor",
   {
     description:
-      "Use when: a tool returns a permission or 'unable to open' error, or you want a full setup diagnostic before querying or exporting.\n" +
-      "Returns: five checks — Python interpreter (path + version; warns below 3.11), osxphotos install, sidecar mode (persistent vs one-shot, plus last respawn), Photos library readability, and Full Disk Access — each reported ok/warn/fail with actionable advice.\n" +
+      "Use when: a tool returns a permission, 'unable to open', or 'write tools are disabled' error, or you want a full setup diagnostic before querying, exporting, or writing.\n" +
+      "Returns: six checks — Python interpreter (path + version; warns below 3.11), osxphotos install, sidecar mode (persistent vs one-shot, plus last respawn), the write-tools gate (enabled/disabled, with the opt-in recipe and — when enabled — whether the photoscript backend and Photos.app look usable), Photos library readability, and Full Disk Access — each reported ok/warn/fail with actionable advice.\n" +
       "Do not use when: you only need the lightweight is-it-working smoke test — use health-check instead.",
     inputSchema: {},
     outputSchema: {
@@ -478,7 +481,7 @@ server.registerTool(
       "Use when: you want to find exact duplicates across the library — cleaning up after a double import, checking whether files were re-uploaded, or auditing before a migration/export.\n" +
       "Returns: groupCount (total duplicate groups found), returned (groups in this response, capped at limit, default 100), and groups ordered newest-first — each with the member UUIDs plus per-member filename, date, size, dimensions, and movie flag. Use get-thumbnail on members to eyeball a group before acting on it.\n" +
       "Do not use when: you're looking for near-duplicates or similar shots — Photos' fingerprint matches EXACT duplicates (identical image data) only; edited copies, resized versions, and burst siblings will NOT group.\n" +
-      "Safety: read-only. This server cannot delete photos (Photos exposes no scriptable delete) — to act on duplicates, collect them into a quarantine album in Photos.app and review/delete there.",
+      "Safety: read-only. This server cannot delete photos — to act on duplicates, quarantine the extra copies into an album (create-album + add-to-album when writes are enabled, otherwise by hand in Photos.app) and review/delete inside Photos.app.",
     inputSchema: {
       ...libraryArg,
       limit: z
@@ -697,6 +700,239 @@ server.registerTool(
     }
     return successResponse(lines.join("\n"), { ...result });
   }, "export")
+);
+
+// ---------------------------------------------------------------------------
+// Write tools — OPT-IN, gated behind APPLE_PHOTOS_MCP_ENABLE_WRITES.
+//
+// Always registered (MCP clients cache the tool list at startup, so hiding
+// them would cost discoverability without adding safety); when the gate is
+// closed every call returns a clear how-to-enable error. The gate is enforced
+// in PhotosManager before anything spawns, and again inside the Python
+// sidecar. None of these tools can delete a photo from the library.
+// ---------------------------------------------------------------------------
+
+/** Every write tool result's album projection. */
+const writeAlbumOutput = {
+  album: z
+    .object({
+      uuid: z.string().optional(),
+      name: z.string().optional(),
+      path: z.string().optional(),
+    })
+    .passthrough()
+    .optional(),
+};
+
+// --- create-album ---
+server.registerTool(
+  "create-album",
+  {
+    description:
+      "Use when: you need an album to file photos into — a new album by name, optionally nested inside a folder path (e.g. for a quarantine album before a dedupe review, or a per-trip album).\n" +
+      "Returns: album {uuid, name, path} and created — false means an album of that name already existed and was returned instead of creating a duplicate (idempotent: safe to re-run; without folder the name is matched anywhere in the library, with folder only inside that folder).\n" +
+      "Do not use when: you want to list existing albums — use list-albums; or you want to put photos into the album — follow up with add-to-album.\n" +
+      "Safety: WRITE tool — disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Only creates albums/folders; never deletes, moves, or modifies photos. Drives Photos.app via AppleScript: Photos is launched if not running, and macOS Automation permission is required (one-time system prompt on first write). Writes always target the library currently open in Photos.app — there is no library parameter.",
+    inputSchema: {
+      name: z.string().min(1).max(255).describe("Album name"),
+      folder: z
+        .string()
+        .min(1)
+        .max(1024)
+        .optional()
+        .describe(
+          'Folder path to nest the album under, "/"-separated for nesting ' +
+            '(e.g. "Trips/2026"); folders are created as needed'
+        ),
+    },
+    outputSchema: {
+      ...writeAlbumOutput,
+      created: z.boolean().optional(),
+    },
+  },
+  withErrorHandling(async ({ name, folder }) => {
+    const result = await manager.createAlbum(name, folder);
+    const verb = result.created ? "Created album" : "Album already exists";
+    return successResponse(`${verb}: ${result.album.path} (${result.album.uuid})`, {
+      ...result,
+    });
+  }, "create-album")
+);
+
+// --- add-to-album ---
+server.registerTool(
+  "add-to-album",
+  {
+    description:
+      "Use when: you have photo UUIDs (from query / find-duplicates) and want to file them into an album — e.g. collecting duplicate extras into a quarantine album, or filing a trip's photos.\n" +
+      "Returns: the album {uuid, name, path}, addedCount, added (UUIDs newly added), alreadyPresent (UUIDs that were already members — adding is idempotent), and notFound (requested UUIDs that don't exist in the library). Fails only when the album doesn't exist or NO requested photo exists.\n" +
+      "Do not use when: the album doesn't exist yet — call create-album first; or you want photos OUT of an album — use remove-from-album.\n" +
+      "Safety: WRITE tool — disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Changes album membership only: photos are never copied, modified, or deleted, and each target is validated to exist first. Max 100 UUIDs per call. Drives Photos.app via AppleScript (launches it if needed; requires macOS Automation permission — one-time prompt). Writes target the library currently open in Photos.app.",
+    inputSchema: {
+      album: z
+        .string()
+        .min(1)
+        .max(1024)
+        .describe("Album name or UUID (UUID-looking values try the id lookup first)"),
+      uuid: z
+        .array(uuidSchema)
+        .min(1)
+        .max(100)
+        .describe("Photo UUID(s) to add (1–100, as returned by query)"),
+    },
+    outputSchema: {
+      ...writeAlbumOutput,
+      addedCount: z.number().optional(),
+      added: z.array(z.string()).optional(),
+      alreadyPresent: z.array(z.string()).optional(),
+      notFound: z.array(z.string()).optional(),
+    },
+  },
+  withErrorHandling(async ({ album, uuid }) => {
+    const result = await manager.addToAlbum(album, uuid);
+    const lines = [
+      `Album:           ${result.album.path} (${result.album.uuid})`,
+      `Added:           ${result.addedCount}`,
+    ];
+    if (result.alreadyPresent.length) {
+      lines.push(`Already present: ${result.alreadyPresent.length}`);
+    }
+    if (result.notFound.length) {
+      lines.push(`Not found:       ${result.notFound.join(", ")}`);
+    }
+    return successResponse(lines.join("\n"), { ...result });
+  }, "add-to-album")
+);
+
+// --- remove-from-album ---
+server.registerTool(
+  "remove-from-album",
+  {
+    description:
+      "Use when: you want to take photos OUT of an album — undoing a mis-filing, or clearing reviewed items from a quarantine album. This removes ALBUM MEMBERSHIP only.\n" +
+      "Returns: the album AFTER the operation ({uuid, name, path} — note the uuid CHANGES when anything was removed), removedCount, removed, notInAlbum (requested UUIDs that weren't members — no-ops), albumRecreated, and previousAlbumUuid.\n" +
+      "Do not use when: you want to delete photos from the library — this server cannot delete photos at all (quarantine them in an album and review in Photos.app instead); or the photos aren't in the album (harmless, but pointless).\n" +
+      "Safety: WRITE tool — disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). NEVER deletes photos from the library — removed photos stay in All Photos and every other album. Photos' AppleScript has no remove-from-album verb, so the album is REBUILT (same name and remaining photos): its UUID changes and any custom manual sort order is lost; re-fetch the album UUID from the response. When none of the UUIDs are members, nothing is rebuilt. Max 100 UUIDs per call. Drives Photos.app via AppleScript (requires macOS Automation permission). Writes target the library currently open in Photos.app.",
+    inputSchema: {
+      album: z
+        .string()
+        .min(1)
+        .max(1024)
+        .describe("Album name or UUID (UUID-looking values try the id lookup first)"),
+      uuid: z
+        .array(uuidSchema)
+        .min(1)
+        .max(100)
+        .describe("Photo UUID(s) to remove from the album (1–100)"),
+    },
+    outputSchema: {
+      ...writeAlbumOutput,
+      removedCount: z.number().optional(),
+      removed: z.array(z.string()).optional(),
+      notInAlbum: z.array(z.string()).optional(),
+      albumRecreated: z.boolean().optional(),
+      previousAlbumUuid: z.string().optional(),
+    },
+  },
+  withErrorHandling(async ({ album, uuid }) => {
+    const result = await manager.removeFromAlbum(album, uuid);
+    const lines = [
+      `Album:        ${result.album.path} (${result.album.uuid})`,
+      `Removed:      ${result.removedCount} (from the album only — photos stay in the library)`,
+    ];
+    if (result.albumRecreated) {
+      lines.push(
+        `Note:         album rebuilt — its UUID changed (was ${result.previousAlbumUuid})`
+      );
+    }
+    if (result.notInAlbum.length) {
+      lines.push(`Not in album: ${result.notInAlbum.join(", ")}`);
+    }
+    return successResponse(lines.join("\n"), { ...result });
+  }, "remove-from-album")
+);
+
+// --- set-photo-metadata ---
+server.registerTool(
+  "set-photo-metadata",
+  {
+    description:
+      "Use when: you want to set a photo's title, description, or favorite flag — captioning passes, marking the best shot of a burst, titling scans.\n" +
+      "Returns: uuid, updated (which fields were written), and the full before/after values of all three fields — so any change can be reverted by writing the before values back.\n" +
+      "Do not use when: you want keywords — use set-keywords (it has union semantics; this tool doesn't touch keywords); or you only want to READ metadata — use get-photo.\n" +
+      "Safety: WRITE tool — disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Metadata only — never touches the image asset, and only the fields you pass are modified (an empty string clears title/description). The target photo is validated to exist first. Drives Photos.app via AppleScript (requires macOS Automation permission). Writes target the library currently open in Photos.app.",
+    inputSchema: {
+      uuid: uuidSchema.describe("Photo UUID (hex-with-dashes, as returned by query)"),
+      title: z.string().max(255).optional().describe("New title (empty string clears it)"),
+      description: z
+        .string()
+        .max(2048)
+        .optional()
+        .describe("New description (empty string clears it)"),
+      favorite: z.boolean().optional().describe("Set or clear the favorite flag"),
+    },
+    outputSchema: {
+      uuid: z.string().optional(),
+      updated: z.array(z.string()).optional(),
+      before: z.object({}).passthrough().optional(),
+      after: z.object({}).passthrough().optional(),
+    },
+  },
+  withErrorHandling(async ({ uuid, title, description, favorite }) => {
+    const result = await manager.setPhotoMetadata(uuid, { title, description, favorite });
+    const lines = [`Updated ${result.updated.join(", ")} on ${result.uuid}:`];
+    for (const field of result.updated) {
+      const key = field as keyof typeof result.before;
+      lines.push(
+        `  ${field}: ${JSON.stringify(result.before[key])} → ${JSON.stringify(result.after[key])}`
+      );
+    }
+    return successResponse(lines.join("\n"), { ...result });
+  }, "set-photo-metadata")
+);
+
+// --- set-keywords ---
+server.registerTool(
+  "set-keywords",
+  {
+    description:
+      "Use when: you want to add and/or remove keywords (tags) on a photo — tagging workflows, fixing a mis-tag — without disturbing its other keywords.\n" +
+      "Returns: uuid, before/after keyword lists (revert by re-running with the diff inverted), added and removed (what actually changed — adding an existing keyword or removing an absent one is a no-op), and changed.\n" +
+      "Do not use when: you want to browse keywords — use list-keywords; or find photos by keyword — use query. A keyword passed in both add and remove is rejected.\n" +
+      "Safety: WRITE tool — disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). UNION semantics — the photo's current keywords are read first and edits are merged in, so existing keywords you don't mention are ALWAYS preserved (never a blind replace). Metadata only — the image asset is untouched; the target photo is validated to exist first. Drives Photos.app via AppleScript (requires macOS Automation permission). Writes target the library currently open in Photos.app.",
+    inputSchema: {
+      uuid: uuidSchema.describe("Photo UUID (hex-with-dashes, as returned by query)"),
+      add: z
+        .array(z.string().min(1).max(255))
+        .max(100)
+        .optional()
+        .describe("Keywords to add (created in Photos if new)"),
+      remove: z
+        .array(z.string().min(1).max(255))
+        .max(100)
+        .optional()
+        .describe("Keywords to remove from this photo (exact match)"),
+    },
+    outputSchema: {
+      uuid: z.string().optional(),
+      before: z.array(z.string()).optional(),
+      after: z.array(z.string()).optional(),
+      added: z.array(z.string()).optional(),
+      removed: z.array(z.string()).optional(),
+      changed: z.boolean().optional(),
+    },
+  },
+  withErrorHandling(async ({ uuid, add, remove }) => {
+    const result = await manager.setKeywords(uuid, { add, remove });
+    const lines = [
+      `Keywords on ${result.uuid}${result.changed ? "" : " (no change needed)"}:`,
+      `  before: ${result.before.length ? result.before.join(", ") : "(none)"}`,
+      `  after:  ${result.after.length ? result.after.join(", ") : "(none)"}`,
+    ];
+    if (result.added.length) lines.push(`  added:   ${result.added.join(", ")}`);
+    if (result.removed.length) lines.push(`  removed: ${result.removed.join(", ")}`);
+    return successResponse(lines.join("\n"), { ...result });
+  }, "set-keywords")
 );
 
 // Register read-only resources (photos://library, albums, persons, keywords,

--- a/src/services/photosManager.ts
+++ b/src/services/photosManager.ts
@@ -5,8 +5,11 @@ import { runPhotosReader, checkDependencies, sidecarBusy, isVenvReady } from "..
 import type { SidecarProgress } from "../utils/sidecarClient.js";
 import { FDA_REMEDIATION } from "../utils/docsUrls.js";
 import { resolveExportDest } from "../utils/exportPath.js";
+import { assertWritesEnabled } from "../utils/writeGate.js";
 import type {
+  AddToAlbumResult,
   AlbumInfo,
+  CreateAlbumResult,
   DuplicateGroupsResult,
   ExportResult,
   FolderInfo,
@@ -17,6 +20,9 @@ import type {
   PhotoDetail,
   QueryFilters,
   QueryResult,
+  RemoveFromAlbumResult,
+  SetKeywordsResult,
+  SetPhotoMetadataResult,
   ThumbnailResult,
 } from "../types.js";
 
@@ -71,6 +77,16 @@ const CACHEABLE_COMMANDS = new Set([
 
 /** Keep the cache tiny — it only needs to absorb repeat catalog lookups. */
 const MAX_CACHE_ENTRIES = 8;
+
+/**
+ * Sidecar timeouts for the write commands. Generous because a write drives
+ * Photos.app over AppleScript — the first call may LAUNCH Photos (photoscript
+ * waits up to 300s for it) and every AppleScript round-trip is slow-ish.
+ * remove-from-album additionally REBUILDS the album (Photos has no remove
+ * verb), which scales with the album's size, so it gets the largest budget.
+ */
+const WRITE_TIMEOUT_MS = 5 * 60 * 1000;
+const ALBUM_REBUILD_TIMEOUT_MS = 10 * 60 * 1000;
 
 interface CacheEntry {
   mtimeMs: number;
@@ -376,6 +392,115 @@ export class PhotosManager {
     const args = this.libraryArgs(library);
     if (limit !== undefined) args.push(flagArg("--limit", limit));
     return this.run("list-persons", args, undefined, library);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write tools (opt-in, gated behind APPLE_PHOTOS_MCP_ENABLE_WRITES)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Shared write path: enforce the opt-in gate BEFORE anything spawns, run the
+   * sidecar write command, and force-invalidate the metadata cache afterwards.
+   *
+   * The cache clear is unconditional (finally) and deliberately does NOT trust
+   * the Photos.sqlite mtime bust: Photos commits through SQLite WAL, so the
+   * main DB file's mtime may not change until a later checkpoint — an
+   * mtime-validated hit could serve a pre-write albums list. A failed write
+   * clears too (it may have partially mutated, e.g. a remove that died
+   * mid-rebuild). The Python sidecar drops its resident PhotosDB for the same
+   * reason, so the next read re-parses. Write commands are never in
+   * CACHEABLE_COMMANDS, so nothing here can populate the cache either.
+   */
+  private async runWrite<T>(command: string, args: string[], timeoutMs: number): Promise<T> {
+    assertWritesEnabled();
+    try {
+      return await this.run<T>(command, args, timeoutMs);
+    } finally {
+      this.cache.clear();
+    }
+  }
+
+  /**
+   * Create an album, or return the existing album of that name
+   * (created=false). folder is a "/"-separated folder path, created as needed.
+   */
+  async createAlbum(name: string, folder?: string): Promise<CreateAlbumResult> {
+    const args = [flagArg("--name", name)];
+    if (folder !== undefined) args.push(flagArg("--folder", folder));
+    return this.runWrite<CreateAlbumResult>("create-album", args, WRITE_TIMEOUT_MS);
+  }
+
+  /** Add photos (by UUID) to an album (by name or UUID). Idempotent. */
+  async addToAlbum(album: string, uuids: string[]): Promise<AddToAlbumResult> {
+    if (uuids.length === 0) {
+      throw new Error("At least one UUID is required");
+    }
+    const args = [flagArg("--album", album)];
+    for (const uuid of uuids) {
+      args.push(flagArg("--uuid", uuid));
+    }
+    return this.runWrite<AddToAlbumResult>("add-to-album", args, WRITE_TIMEOUT_MS);
+  }
+
+  /**
+   * Remove photos (by UUID) from an album — never from the library. The album
+   * is rebuilt to effect the removal (its UUID changes; see the tool docs).
+   */
+  async removeFromAlbum(album: string, uuids: string[]): Promise<RemoveFromAlbumResult> {
+    if (uuids.length === 0) {
+      throw new Error("At least one UUID is required");
+    }
+    const args = [flagArg("--album", album)];
+    for (const uuid of uuids) {
+      args.push(flagArg("--uuid", uuid));
+    }
+    return this.runWrite<RemoveFromAlbumResult>(
+      "remove-from-album",
+      args,
+      ALBUM_REBUILD_TIMEOUT_MS
+    );
+  }
+
+  /** Set title / description / favorite on one photo (only the fields given). */
+  async setPhotoMetadata(
+    uuid: string,
+    updates: { title?: string; description?: string; favorite?: boolean }
+  ): Promise<SetPhotoMetadataResult> {
+    const args = [flagArg("--uuid", uuid)];
+    if (updates.title !== undefined) args.push(flagArg("--title", updates.title));
+    if (updates.description !== undefined) {
+      args.push(flagArg("--description", updates.description));
+    }
+    if (updates.favorite !== undefined) {
+      args.push(flagArg("--favorite", updates.favorite ? "true" : "false"));
+    }
+    if (args.length === 1) {
+      throw new Error("Nothing to update: pass at least one of title, description, favorite");
+    }
+    return this.runWrite<SetPhotoMetadataResult>("set-photo-metadata", args, WRITE_TIMEOUT_MS);
+  }
+
+  /**
+   * Add/remove keywords on one photo with union semantics — existing keywords
+   * not mentioned are preserved (the sidecar merges against the live list).
+   */
+  async setKeywords(
+    uuid: string,
+    edits: { add?: string[]; remove?: string[] }
+  ): Promise<SetKeywordsResult> {
+    const add = edits.add ?? [];
+    const remove = edits.remove ?? [];
+    if (add.length === 0 && remove.length === 0) {
+      throw new Error("Nothing to do: pass add and/or remove");
+    }
+    const args = [flagArg("--uuid", uuid)];
+    for (const k of add) {
+      args.push(flagArg("--add", k));
+    }
+    for (const k of remove) {
+      args.push(flagArg("--remove", k));
+    }
+    return this.runWrite<SetKeywordsResult>("set-keywords", args, WRITE_TIMEOUT_MS);
   }
 
   async exportPhotos(

--- a/src/tools/doctor.ts
+++ b/src/tools/doctor.ts
@@ -3,15 +3,28 @@
  * apple-photos-mcp setup — the resolved Python interpreter (path + version, so
  * an old stock Python is visible at a glance), osxphotos installation, the
  * sidecar execution mode (persistent serve process vs one-shot fallback, with
- * the last respawn), Photos library reachability, and Full Disk Access
- * (required for the host process to read the library) — each reported as
- * ok / warn / fail with an actionable message.
+ * the last respawn), the write-tools gate (read-only by default; reports how
+ * to opt in, and whether the photoscript backend looks usable when enabled),
+ * Photos library reachability, and Full Disk Access (required for the host
+ * process to read the library) — each reported as ok / warn / fail with an
+ * actionable message.
  *
  * @module tools/doctor
  */
+import { existsSync } from "node:fs";
 import type { PhotosManager } from "../services/photosManager.js";
-import { checkDependencies, getPythonInfo, getSidecarInfo, sidecarBusy } from "../utils/python.js";
-import { FDA_REMEDIATION, TROUBLESHOOTING_URL } from "../utils/docsUrls.js";
+import {
+  checkDependencies,
+  checkPhotoscript,
+  getPythonInfo,
+  getSidecarInfo,
+  sidecarBusy,
+} from "../utils/python.js";
+import { FDA_REMEDIATION, TROUBLESHOOTING_URL, WRITE_TOOLS_URL } from "../utils/docsUrls.js";
+import { writesEnabled, WRITES_ENV } from "../utils/writeGate.js";
+
+/** Where macOS installs Photos.app (the write tools drive it via AppleScript). */
+const PHOTOS_APP_PATH = "/System/Applications/Photos.app";
 
 export type CheckStatus = "ok" | "warn" | "fail";
 export interface DoctorCheck {
@@ -33,12 +46,13 @@ function looksLikePermissionError(message: string): boolean {
  * Run all diagnostic checks. This function NEVER throws — every probe is wrapped
  * in try/catch and converted to a fail/warn check.
  *
- * Gate interaction: checks 1–2 are light interpreter probes (python --version,
- * `import osxphotos`) that never open the Photos DB, so they always run —
- * even while a long sidecar operation (query/export) holds the serial gate.
- * Check 3 (and the Full-Disk-Access check derived from it) needs a real
- * DB-touching sidecar call; when the gate is busy it is SKIPPED with a warn
- * instead of queueing doctor behind an operation that can run for minutes.
+ * Gate interaction: checks 1–4 are light probes (python --version, `import
+ * osxphotos`/`import photoscript`, pure-TS state) that never open the Photos
+ * DB, so they always run — even while a long sidecar operation (query/export)
+ * holds the serial gate. Check 5 (and the Full-Disk-Access check derived from
+ * it) needs a real DB-touching sidecar call; when the gate is busy it is
+ * SKIPPED with a warn instead of queueing doctor behind an operation that can
+ * run for minutes.
  */
 export async function runDoctor(manager: PhotosManager): Promise<DoctorReport> {
   const checks: DoctorCheck[] = [];
@@ -136,7 +150,47 @@ export async function runDoctor(manager: PhotosManager): Promise<DoctorReport> {
     });
   }
 
-  // 4. Photos library reachability. We remember whether it was a permission
+  // 4. Write-tools gate. Disabled is the healthy default (read-only server) —
+  //    reported ok with the opt-in recipe. When ENABLED, verify the parts that
+  //    can be checked without side effects: photoscript importable and
+  //    Photos.app present. macOS Automation permission is deliberately NOT
+  //    probed — any AppleScript sent to Photos would launch it and/or trigger
+  //    the TCC prompt, so doctor only explains that the first write prompts.
+  try {
+    if (!writesEnabled()) {
+      checks.push({
+        name: "writes",
+        status: "ok",
+        detail:
+          `disabled — server is read-only (the default). To enable the write tools ` +
+          `(create-album, add-to-album, remove-from-album, set-photo-metadata, ` +
+          `set-keywords), set ${WRITES_ENV}=1 in the server env or config.json and ` +
+          `restart. See ${WRITE_TOOLS_URL}`,
+      });
+    } else {
+      const ps = await checkPhotoscript();
+      const photosAppPresent = existsSync(PHOTOS_APP_PATH);
+      checks.push({
+        name: "writes",
+        status: !ps.ok ? "fail" : photosAppPresent ? "ok" : "warn",
+        detail:
+          `ENABLED — the write tools can modify this Photos library (album membership, ` +
+          `titles, descriptions, keywords, favorites; never deleting photos). ` +
+          `${ps.message}; Photos.app ${photosAppPresent ? "present" : `NOT found at ${PHOTOS_APP_PATH}`}. ` +
+          `Writes drive Photos.app via AppleScript and need macOS Automation permission ` +
+          `for the host app — macOS asks via a one-time prompt on the first write ` +
+          `(not verifiable here without triggering that prompt).`,
+      });
+    }
+  } catch (e) {
+    checks.push({
+      name: "writes",
+      status: "warn",
+      detail: `could not determine the write-tools state: ${String(e)}`,
+    });
+  }
+
+  // 5. Photos library reachability. We remember whether it was a permission
   //    error so the full_disk_access check can be derived from it. Skipped
   //    (warn) while another sidecar operation holds the gate — doctor must
   //    respond promptly, not queue behind a minutes-long query/export.
@@ -176,7 +230,7 @@ export async function runDoctor(manager: PhotosManager): Promise<DoctorReport> {
     });
   }
 
-  // 5. Full Disk Access — derived from the photos_library check.
+  // 6. Full Disk Access — derived from the photos_library check.
   if (libraryOk) {
     checks.push({
       name: "full_disk_access",

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,3 +213,72 @@ export interface QueryFilters {
   video?: boolean;
   newestFirst?: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Write-tool results (opt-in, gated behind APPLE_PHOTOS_MCP_ENABLE_WRITES)
+// ---------------------------------------------------------------------------
+
+/** The album an album-write acted on (photoscript projection). */
+export interface WriteAlbumRef {
+  uuid: string;
+  name: string;
+  /** Library path incl. the album name, "/"-separated (e.g. "Trips/2026/Camping"). */
+  path: string;
+}
+
+export interface CreateAlbumResult {
+  album: WriteAlbumRef;
+  /** false when an album of that name already existed and was returned instead. */
+  created: boolean;
+}
+
+export interface AddToAlbumResult {
+  album: WriteAlbumRef;
+  addedCount: number;
+  added: string[];
+  /** UUIDs that were already in the album (adding is idempotent). */
+  alreadyPresent: string[];
+  /** Requested UUIDs that don't exist in the library. */
+  notFound: string[];
+}
+
+export interface RemoveFromAlbumResult {
+  /** The album AFTER the operation — its uuid CHANGES when albumRecreated. */
+  album: WriteAlbumRef;
+  removedCount: number;
+  removed: string[];
+  /** Requested UUIDs that were not members of the album (no-ops). */
+  notInAlbum: string[];
+  /**
+   * True when the album was rebuilt to effect the removal (Photos' AppleScript
+   * has no remove verb); false when nothing needed removing.
+   */
+  albumRecreated: boolean;
+  /** The album's uuid before the rebuild (present when albumRecreated). */
+  previousAlbumUuid?: string;
+}
+
+export interface PhotoMetadataValues {
+  title: string;
+  description: string;
+  favorite: boolean;
+}
+
+export interface SetPhotoMetadataResult {
+  uuid: string;
+  /** Which fields were written ("title" | "description" | "favorite"). */
+  updated: string[];
+  before: PhotoMetadataValues;
+  after: PhotoMetadataValues;
+}
+
+export interface SetKeywordsResult {
+  uuid: string;
+  before: string[];
+  after: string[];
+  /** Keywords actually added (requested adds already present are omitted). */
+  added: string[];
+  /** Keywords actually removed (requested removes not present are omitted). */
+  removed: string[];
+  changed: boolean;
+}

--- a/src/utils/docsUrls.ts
+++ b/src/utils/docsUrls.ts
@@ -23,6 +23,9 @@ export const TROUBLESHOOTING_URL = `${REPO_URL}#troubleshooting`;
 /** Step-by-step Full Disk Access walkthrough with screenshots. */
 export const FDA_GUIDE_URL = `${REPO_URL}/blob/main/docs/FULL-DISK-ACCESS.md`;
 
+/** README section documenting the opt-in write tools and their gate. */
+export const WRITE_TOOLS_URL = `${REPO_URL}#write-tools-opt-in`;
+
 /**
  * Shared Full-Disk-Access remediation prose. Used verbatim by both the
  * per-tool permission-error augmentation (photosManager) and the doctor's

--- a/src/utils/photos_reader.py
+++ b/src/utils/photos_reader.py
@@ -3,6 +3,12 @@
 Bridge script: queries the Apple Photos library using osxphotos and outputs JSON.
 Called by the TypeScript MCP server via child_process.
 
+Reads go through osxphotos (direct SQLite parse). The OPT-IN write commands
+(create-album, add-to-album, remove-from-album, set-photo-metadata,
+set-keywords) go through photoscript, which drives Photos.app over AppleScript
+— they are refused unless APPLE_PHOTOS_MCP_ENABLE_WRITES is set (the TS layer
+gates them too; this is defense in depth for direct CLI invocation).
+
 Two modes:
 
 - **One-shot (argv)**: `photos_reader.py <command> [--flags]` — runs one command
@@ -31,12 +37,14 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import os
 import re
 import subprocess
 import sys
 import tempfile
 from datetime import date, datetime, timedelta
 from pathlib import Path
+from uuid import uuid4
 
 try:
     import bitmath
@@ -951,6 +959,367 @@ def cmd_export(args):
 
 
 # ---------------------------------------------------------------------------
+# Write commands (photoscript → Photos.app AppleScript) — OPT-IN
+# ---------------------------------------------------------------------------
+#
+# Everything below MODIFIES the user's Photos library and is therefore gated
+# behind APPLE_PHOTOS_MCP_ENABLE_WRITES (checked per command, here AND in the
+# TS layer). Design invariants:
+#
+#   - Writes target the library currently open in Photos.app (normally the
+#     system library) — AppleScript cannot address any other library, so the
+#     write commands deliberately take no --library flag.
+#   - Every target is validated first: unknown photo UUIDs / album names come
+#     back as clear errors (or per-UUID notFound lists for batches), never as
+#     silent no-ops on the wrong object.
+#   - Nothing here can DELETE a photo from the library. remove-from-album
+#     changes album membership only; there is intentionally no delete command
+#     (Photos' AppleScript delete verbs are not exposed as MCP tools).
+#   - After any write the resident PhotosDB cache is dropped: Photos commits
+#     through SQLite WAL, so the Photos.sqlite mtime the cache revalidates on
+#     may not change immediately — trusting it could serve a stale snapshot.
+
+WRITES_ENV = "APPLE_PHOTOS_MCP_ENABLE_WRITES"
+
+# UUID-ish (hex segments and dashes, optional AppleScript "/L0/nnn" suffix) —
+# used to decide whether an album reference should try an id lookup first.
+_UUID_ISH_RE = re.compile(r"^[0-9A-Fa-f-]+(/L0/\d+)?$")
+
+_photoscript_module = None
+
+
+def _writes_enabled() -> bool:
+    value = os.environ.get(WRITES_ENV, "")
+    return value not in ("", "0") and value.lower() != "false"
+
+
+def _require_writes() -> None:
+    if not _writes_enabled():
+        raise RuntimeError(
+            "Write tools are disabled — apple-photos-mcp is read-only by default. "
+            f"Set {WRITES_ENV}=1 in the server's environment (or in "
+            "~/Library/Application Support/apple-photos-mcp/config.json) and restart "
+            "the MCP server to enable them. Run the doctor tool to see the gate "
+            "state, or see "
+            "https://github.com/sweetrb/apple-photos-mcp#write-tools-opt-in"
+        )
+
+
+def _photoscript():
+    """Lazily import photoscript (read-only users never pay for it) and make
+    its AppleScript runner safe for MCP use: photoscript's default retry
+    policy runs `killall Photos` when an AppleScript call times out — an MCP
+    server must NEVER kill the user's Photos.app out from under them, so
+    retries are disabled and timeouts surface as plain errors instead."""
+    global _photoscript_module
+    if _photoscript_module is None:
+        try:
+            import photoscript
+            from photoscript.script_loader import configure_run_script
+        except ImportError as exc:
+            raise RuntimeError(
+                "photoscript not installed. Install it with: pip3 install photoscript, "
+                "or run scripts/setup.sh from a repo checkout (it installs "
+                "requirements.txt into ./venv). Run the doctor tool to diagnose, or see "
+                "https://github.com/sweetrb/apple-photos-mcp#troubleshooting"
+            ) from exc
+        configure_run_script(retry_enabled=False)
+        _photoscript_module = photoscript
+    return _photoscript_module
+
+
+def _run_script(ps, name: str, *args):
+    """One raw AppleScript call via photoscript's runner. Used where the
+    object API would spawn one osascript per photo (Album.photos() constructs
+    a Photo — one existence probe each — for every member; albumPhotes/albumAdd
+    move the whole id list in a single call). photoscript is version-pinned in
+    requirements.txt, so these two handler names are stable."""
+    return ps.script_loader.run_script(name, *args)
+
+
+def _mark_library_written() -> None:
+    """Drop every resident PhotosDB after a write (see invariants above)."""
+    _db_cache.clear()
+
+
+def _bare_uuid(media_id: str) -> str:
+    """Strip the AppleScript '/L0/nnn' suffix: media-item id → osxphotos UUID."""
+    return media_id.split("/")[0]
+
+
+def _album_payload(album) -> dict:
+    return {
+        "uuid": album.uuid,
+        "name": album.name,
+        "path": album.path_str("/"),
+    }
+
+
+def _resolve_album(ps, lib, ref: str):
+    """Resolve an album by UUID or name. UUID-looking refs try the id lookup
+    first and fall back to a name lookup (an album could be *named* like a
+    UUID). Raises with a clear message when nothing matches."""
+    if _UUID_ISH_RE.match(ref):
+        try:
+            return ps.Album(ref)
+        except ValueError:
+            pass  # not a known album id — fall through to the name lookup
+    album = lib.album(ref)
+    if album is None:
+        raise RuntimeError(
+            f"Album not found: {ref!r}. Pass an exact album name or UUID "
+            "(see list-albums), or create it with create-album."
+        )
+    return album
+
+
+def _resolve_photo(ps, uuid: str):
+    """One photo by UUID via Photos.app; same message contract as get-photo."""
+    try:
+        return ps.Photo(uuid)
+    except ValueError:
+        raise RuntimeError(f"Photo not found: {uuid}") from None
+
+
+def _resolve_photos(ps, uuids: list[str]) -> tuple[list, list[str]]:
+    """Batch photo resolution: (found Photo objects, notFound uuids) — dupes
+    collapsed, caller order preserved."""
+    found: list = []
+    not_found: list[str] = []
+    for u in dict.fromkeys(uuids):
+        try:
+            found.append(ps.Photo(u))
+        except ValueError:
+            not_found.append(u)
+    return found, not_found
+
+
+def _temp_album_name(lib) -> str:
+    """A collision-checked scratch-album name for the remove rebuild."""
+    while True:
+        candidate = f"apple-photos-mcp-tmp-{uuid4().hex[:12]}"
+        if lib.album(candidate) is None:
+            return candidate
+
+
+def _merge_keywords(
+    current: list[str], add: list[str], remove: list[str]
+) -> tuple[list[str], list[str], list[str]]:
+    """UNION semantics for set-keywords: start from the photo's CURRENT
+    keywords, drop `remove`, append `add` — never blind-replace, so keywords
+    the caller didn't mention are always preserved. Order: survivors keep
+    their existing order, additions append in caller order.
+
+    Returns (after, added, removed) where added/removed reflect what actually
+    changed (adding an existing keyword or removing an absent one is a no-op).
+    """
+    remove_set = set(remove)
+    after = [k for k in current if k not in remove_set]
+    seen = set(after)
+    added = []
+    for k in add:
+        if k not in seen:
+            after.append(k)
+            seen.add(k)
+            added.append(k)
+    removed = [k for k in dict.fromkeys(current) if k in remove_set]
+    return after, added, removed
+
+
+def cmd_create_album(args):
+    """Create an album (optionally nested in a folder path), or return the
+    existing album of that name with created=false — idempotent by design so
+    re-running a filing workflow never piles up duplicate albums."""
+    _require_writes()
+    ps = _photoscript()
+    lib = ps.PhotosLibrary()
+    try:
+        if args.folder:
+            # "/"-separated folder path; each segment is created if missing
+            # (folder names containing a literal "/" are not addressable).
+            path = [seg for seg in args.folder.split("/") if seg.strip()]
+            if not path:
+                raise RuntimeError("folder must contain at least one folder name")
+            folder = lib.make_folders(path)
+            existing = folder.album(args.name)
+            if existing is not None:
+                return {"album": _album_payload(existing), "created": False}
+            return {"album": _album_payload(folder.create_album(args.name)), "created": True}
+        # No folder: the idempotency check matches an album of that name
+        # ANYWHERE in the library (first match), so re-runs find the album
+        # even if it was originally created inside a folder.
+        existing = lib.album(args.name)
+        if existing is not None:
+            return {"album": _album_payload(existing), "created": False}
+        return {"album": _album_payload(lib.create_album(args.name)), "created": True}
+    finally:
+        _mark_library_written()
+
+
+def cmd_add_to_album(args):
+    """Add photos (by UUID) to an album. Idempotent: photos already in the
+    album are reported in alreadyPresent, not added twice (Photos albums are
+    sets). Unknown UUIDs are reported in notFound; the batch fails only when
+    NO requested photo exists."""
+    _require_writes()
+    ps = _photoscript()
+    lib = ps.PhotosLibrary()
+    try:
+        album = _resolve_album(ps, lib, args.album)
+        photos, not_found = _resolve_photos(ps, args.uuid)
+        if not photos:
+            raise RuntimeError(
+                "None of the requested photos exist in the library: "
+                + ", ".join(not_found)
+            )
+        members = {_bare_uuid(m) for m in _run_script(ps, "albumPhotes", album.id)}
+        to_add = [p for p in photos if p.uuid not in members]
+        already = [p.uuid for p in photos if p.uuid in members]
+        if to_add:
+            # albumAdd verifies membership after adding (retrying internally),
+            # so a normal return means every photo really is in the album.
+            _run_script(ps, "albumAdd", album.id, [p.id for p in to_add])
+        return {
+            "album": _album_payload(album),
+            "addedCount": len(to_add),
+            "added": [p.uuid for p in to_add],
+            "alreadyPresent": already,
+            "notFound": not_found,
+        }
+    finally:
+        _mark_library_written()
+
+
+def cmd_remove_from_album(args):
+    """Remove photos (by UUID) from an album — NEVER from the library: the
+    photos stay in All Photos and every other album.
+
+    Photos' AppleScript dictionary has no remove-from-album verb, so removal
+    REBUILDS the album (the same approach photoscript's Album.remove uses,
+    implemented here with bulk id calls instead of per-photo objects): create
+    a scratch album in the same folder, add every kept photo, delete the
+    original, rename. Consequences callers must know: the album's UUID CHANGES
+    (albumRecreated=true, previousAlbumUuid reports the old one) and any custom
+    manual sort order is lost. When none of the UUIDs are in the album the
+    rebuild is skipped entirely (albumRecreated=false)."""
+    _require_writes()
+    ps = _photoscript()
+    lib = ps.PhotosLibrary()
+    try:
+        album = _resolve_album(ps, lib, args.album)
+        requested = list(dict.fromkeys(args.uuid))
+        member_ids = _run_script(ps, "albumPhotes", album.id)
+        members = {_bare_uuid(m) for m in member_ids}
+        to_remove = [u for u in requested if u in members]
+        not_in_album = [u for u in requested if u not in members]
+        if not to_remove:
+            return {
+                "album": _album_payload(album),
+                "removedCount": 0,
+                "removed": [],
+                "notInAlbum": not_in_album,
+                "albumRecreated": False,
+            }
+
+        remove_set = set(to_remove)
+        keep_ids = [m for m in member_ids if _bare_uuid(m) not in remove_set]
+        previous_uuid = album.uuid
+        name = album.name
+        new_album = lib.create_album(_temp_album_name(lib), folder=album.parent)
+        try:
+            if keep_ids:
+                _run_script(ps, "albumAdd", new_album.id, keep_ids)
+        except Exception:
+            # Rebuild failed before anything was destroyed: drop the scratch
+            # album and leave the original untouched.
+            lib.delete_album(new_album)
+            raise
+        lib.delete_album(album)
+        new_album.name = name
+        return {
+            "album": _album_payload(new_album),
+            "removedCount": len(to_remove),
+            "removed": to_remove,
+            "notInAlbum": not_in_album,
+            "albumRecreated": True,
+            "previousAlbumUuid": previous_uuid,
+        }
+    finally:
+        _mark_library_written()
+
+
+def cmd_set_photo_metadata(args):
+    """Set title / description / favorite on one photo. Only the fields passed
+    are touched; before/after values are echoed so a caller can revert."""
+    _require_writes()
+    if args.title is None and args.description is None and args.favorite is None:
+        raise RuntimeError(
+            "Nothing to update: pass at least one of --title, --description, --favorite"
+        )
+    ps = _photoscript()
+    try:
+        photo = _resolve_photo(ps, args.uuid)
+        before = {
+            "title": photo.title,
+            "description": photo.description,
+            "favorite": photo.favorite,
+        }
+        updated = []
+        if args.title is not None:
+            photo.title = args.title
+            updated.append("title")
+        if args.description is not None:
+            photo.description = args.description
+            updated.append("description")
+        if args.favorite is not None:
+            photo.favorite = args.favorite == "true"
+            updated.append("favorite")
+        after = {
+            "title": photo.title,
+            "description": photo.description,
+            "favorite": photo.favorite,
+        }
+        return {"uuid": photo.uuid, "updated": updated, "before": before, "after": after}
+    finally:
+        _mark_library_written()
+
+
+def cmd_set_keywords(args):
+    """Add/remove keywords on one photo with UNION semantics (_merge_keywords):
+    existing keywords the caller didn't mention are always preserved — the
+    photoscript setter replaces the whole list, so the merge happens here
+    against the photo's live keywords. Echoes before/after for revertability."""
+    _require_writes()
+    add = args.add or []
+    remove = args.remove or []
+    if not add and not remove:
+        raise RuntimeError("Nothing to do: pass --add and/or --remove")
+    overlap = sorted(set(add) & set(remove))
+    if overlap:
+        raise RuntimeError(
+            "Keywords cannot be both added and removed: " + ", ".join(overlap)
+        )
+    ps = _photoscript()
+    try:
+        photo = _resolve_photo(ps, args.uuid)
+        before = list(photo.keywords)
+        after, added, removed = _merge_keywords(before, add, remove)
+        changed = after != before
+        if changed:
+            photo.keywords = after
+        return {
+            "uuid": photo.uuid,
+            "before": before,
+            "after": after,
+            "added": added,
+            "removed": removed,
+            "changed": changed,
+        }
+    finally:
+        _mark_library_written()
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -1064,6 +1433,34 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--raw", action="store_true", help="Include raw image")
     p.add_argument("--overwrite", action="store_true", help="Overwrite existing files")
 
+    # --- write commands (gated; no --library: writes always target the
+    #     library currently open in Photos.app) ---
+    p = sub.add_parser("create-album")
+    p.add_argument("--name", required=True, help="Album name")
+    p.add_argument(
+        "--folder",
+        help='Folder path to nest the album under ("A/B"); folders are created as needed',
+    )
+
+    p = sub.add_parser("add-to-album")
+    p.add_argument("--album", required=True, help="Album name or UUID")
+    p.add_argument("--uuid", action="append", required=True, help="Photo UUID(s) to add")
+
+    p = sub.add_parser("remove-from-album")
+    p.add_argument("--album", required=True, help="Album name or UUID")
+    p.add_argument("--uuid", action="append", required=True, help="Photo UUID(s) to remove")
+
+    p = sub.add_parser("set-photo-metadata")
+    p.add_argument("--uuid", required=True, help="Photo UUID")
+    p.add_argument("--title", help="New title (empty string clears)")
+    p.add_argument("--description", help="New description (empty string clears)")
+    p.add_argument("--favorite", choices=["true", "false"], help="Favorite flag")
+
+    p = sub.add_parser("set-keywords")
+    p.add_argument("--uuid", required=True, help="Photo UUID")
+    p.add_argument("--add", action="append", help="Keyword to add (repeatable)")
+    p.add_argument("--remove", action="append", help="Keyword to remove (repeatable)")
+
     return parser
 
 
@@ -1080,6 +1477,12 @@ HANDLERS = {
     "list-keywords": cmd_list_keywords,
     "list-persons": cmd_list_persons,
     "export": cmd_export,
+    # write commands (gated behind APPLE_PHOTOS_MCP_ENABLE_WRITES)
+    "create-album": cmd_create_album,
+    "add-to-album": cmd_add_to_album,
+    "remove-from-album": cmd_remove_from_album,
+    "set-photo-metadata": cmd_set_photo_metadata,
+    "set-keywords": cmd_set_keywords,
 }
 
 

--- a/src/utils/python.ts
+++ b/src/utils/python.ts
@@ -705,6 +705,34 @@ export async function getPythonInfo(): Promise<PythonInterpreterInfo | null> {
 }
 
 /**
+ * Probe that photoscript (the write-tools backend — it drives Photos.app over
+ * AppleScript) is importable by the resolved interpreter. Ungated and
+ * sub-second like checkDependencies; only the doctor's writes check calls it,
+ * and only when the write gate is enabled. The import alone runs no
+ * AppleScript, so it can never trigger a macOS Automation prompt.
+ */
+export async function checkPhotoscript(): Promise<{ ok: boolean; message: string }> {
+  try {
+    const python = resolvePython();
+    const version = (
+      await execFileAsync(python, [
+        "-c",
+        'import photoscript, importlib.metadata; print(importlib.metadata.version("photoscript"))',
+      ])
+    ).trim();
+    return { ok: true, message: `photoscript ${version} available` };
+  } catch {
+    return {
+      ok: false,
+      message:
+        `photoscript not installed. Install it with: pip3 install photoscript, or run ` +
+        `scripts/setup.sh from a repo checkout. Run the doctor tool to diagnose, or see ` +
+        `${TROUBLESHOOTING_URL}`,
+    };
+  }
+}
+
+/**
  * Probe that osxphotos is importable by the resolved interpreter. Ungated (no
  * Photos DB access; sub-second), so doctor/health-check can classify a missing
  * install even while a long sidecar operation holds the gate.

--- a/src/utils/writeGate.ts
+++ b/src/utils/writeGate.ts
@@ -1,0 +1,48 @@
+/**
+ * The write-tools gate.
+ *
+ * apple-photos-mcp is read-only by default — the 2.0.0 write tools
+ * (create-album, add-to-album, remove-from-album, set-photo-metadata,
+ * set-keywords) only work when APPLE_PHOTOS_MCP_ENABLE_WRITES is set to a
+ * truthy value ("1"/"true"/anything but ""/"0"/"false"), via the environment
+ * or the config.json file the server loads at startup (services/fileConfig).
+ *
+ * The write tools are ALWAYS REGISTERED and return this gate's error when
+ * disabled, rather than being hidden from the tool list. Rationale: MCP
+ * clients cache the tool list at server startup, so conditional registration
+ * buys no security (flipping the env needs a restart either way) — but it
+ * costs discoverability: an agent that can't see the tool can only tell the
+ * user "that's impossible", while an agent that gets this error can explain
+ * exactly how to opt in. The gate is enforced per call in PhotosManager (and
+ * again inside the Python sidecar, for direct CLI invocations).
+ *
+ * @module utils/writeGate
+ */
+import { WRITE_TOOLS_URL } from "./docsUrls.js";
+
+export const WRITES_ENV = "APPLE_PHOTOS_MCP_ENABLE_WRITES";
+
+/** True when the opt-in write gate is open. */
+export function writesEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const value = env[WRITES_ENV];
+  return value !== undefined && value !== "" && value !== "0" && value.toLowerCase() !== "false";
+}
+
+/** The exact user-facing gated-off message (also asserted by tests). */
+export function writesDisabledMessage(): string {
+  return (
+    `Write tools are disabled — apple-photos-mcp is read-only by default. ` +
+    `To enable them, set ${WRITES_ENV}=1 in the server's environment, or add ` +
+    `{"${WRITES_ENV}": "1"} to ` +
+    `~/Library/Application Support/apple-photos-mcp/config.json, then restart ` +
+    `the MCP server. Run the doctor tool to see the gate state, or see ` +
+    `${WRITE_TOOLS_URL}`
+  );
+}
+
+/** Throw the gated-off error unless writes are enabled. */
+export function assertWritesEnabled(env: NodeJS.ProcessEnv = process.env): void {
+  if (!writesEnabled(env)) {
+    throw new Error(writesDisabledMessage());
+  }
+}

--- a/test/fixtures/pyfakes/bitmath/__init__.py
+++ b/test/fixtures/pyfakes/bitmath/__init__.py
@@ -1,0 +1,5 @@
+"""Fake bitmath — photos_reader.py imports it at module level."""
+
+
+def Byte(n):
+    return n

--- a/test/fixtures/pyfakes/osxphotos/__init__.py
+++ b/test/fixtures/pyfakes/osxphotos/__init__.py
@@ -1,0 +1,14 @@
+"""Fake osxphotos — just enough for photos_reader.py to import. The write-tool
+tests never touch the read path, so PhotosDB refuses to construct."""
+
+__version__ = "0.0.0-fake"
+
+
+class PhotosDB:
+    def __init__(self, dbfile=None):
+        raise RuntimeError("fake osxphotos: reads are unavailable in this test harness")
+
+
+class QueryOptions:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs

--- a/test/fixtures/pyfakes/photoscript/__init__.py
+++ b/test/fixtures/pyfakes/photoscript/__init__.py
@@ -1,0 +1,197 @@
+"""Fake photoscript backed by an in-memory library loaded from the JSON file
+named by FAKE_PHOTOSCRIPT_STATE. Mirrors the slice of photoscript 0.5.3's API
+that photos_reader.py's write commands use (Photo/Album/Folder/PhotosLibrary
+plus script_loader.run_script for albumPhotes/albumAdd), so the REAL handler
+logic — gating, validation, union merges, the remove rebuild — runs unmodified
+against deterministic data with no Photos.app, no AppleScript, no TCC.
+
+Every mutation is appended as a JSON line to FAKE_PHOTOSCRIPT_LOG so tests can
+assert exactly which writes happened (and, as importantly, which didn't).
+
+State shape:
+{
+  "albums": [{"uuid", "name", "path", "members": [uuid...], "folder": [..]?}],
+  "photos": {uuid: {"title", "description", "favorite", "keywords": [...]}}
+}
+"""
+
+import json
+import os
+
+_state_cache = None
+
+
+def _state():
+    global _state_cache
+    if _state_cache is None:
+        with open(os.environ["FAKE_PHOTOSCRIPT_STATE"]) as f:
+            _state_cache = json.load(f)
+    return _state_cache
+
+
+def _log(event):
+    path = os.environ.get("FAKE_PHOTOSCRIPT_LOG")
+    if path:
+        with open(path, "a") as f:
+            f.write(json.dumps(event) + "\n")
+
+
+def _album_record(bare_uuid):
+    for a in _state()["albums"]:
+        if a["uuid"] == bare_uuid:
+            return a
+    return None
+
+
+class Photo:
+    def __init__(self, uuid):
+        bare = uuid.split("/")[0]
+        if bare not in _state()["photos"]:
+            raise ValueError(f"Invalid photo id: {bare}")
+        self._uuid = bare
+        self.id = bare + "/L0/001"
+
+    @property
+    def uuid(self):
+        return self._uuid
+
+    def _rec(self):
+        return _state()["photos"][self._uuid]
+
+    @property
+    def title(self):
+        return self._rec().get("title", "")
+
+    @title.setter
+    def title(self, value):
+        self._rec()["title"] = value
+        _log({"op": "set_title", "uuid": self._uuid, "value": value})
+
+    @property
+    def description(self):
+        return self._rec().get("description", "")
+
+    @description.setter
+    def description(self, value):
+        self._rec()["description"] = value
+        _log({"op": "set_description", "uuid": self._uuid, "value": value})
+
+    @property
+    def favorite(self):
+        return self._rec().get("favorite", False)
+
+    @favorite.setter
+    def favorite(self, value):
+        self._rec()["favorite"] = bool(value)
+        _log({"op": "set_favorite", "uuid": self._uuid, "value": bool(value)})
+
+    @property
+    def keywords(self):
+        return list(self._rec().get("keywords", []))
+
+    @keywords.setter
+    def keywords(self, value):
+        self._rec()["keywords"] = list(value)
+        _log({"op": "set_keywords", "uuid": self._uuid, "value": list(value)})
+
+
+class Album:
+    def __init__(self, uuid):
+        bare = uuid.split("/")[0]
+        if _album_record(bare) is None:
+            raise ValueError(f"Invalid album id: {bare}")
+        self._uuid = bare
+        self.id = bare + "/L0/040"
+
+    def _rec(self):
+        return _album_record(self._uuid)
+
+    @property
+    def uuid(self):
+        return self._uuid
+
+    @property
+    def name(self):
+        return self._rec()["name"]
+
+    @name.setter
+    def name(self, value):
+        self._rec()["name"] = value
+        _log({"op": "rename_album", "uuid": self._uuid, "name": value})
+
+    @property
+    def parent(self):
+        folder = self._rec().get("folder")
+        return Folder(folder) if folder else None
+
+    def path_str(self, delim="/"):
+        rec = self._rec()
+        return rec.get("path") or rec["name"]
+
+
+class Folder:
+    def __init__(self, path):
+        self._path = list(path)
+        self.idstring = "folder:" + "/".join(self._path)
+
+    @property
+    def name(self):
+        return self._path[-1]
+
+    def album(self, name):
+        for a in _state()["albums"]:
+            if a["name"] == name and a.get("folder") == self._path:
+                return Album(a["uuid"])
+        return None
+
+    def create_album(self, name):
+        return _create_album(name, folder=self)
+
+
+def _create_album(name, folder=None):
+    n = len(_state()["albums"]) + 1
+    rec = {
+        "uuid": f"CEA{n:03d}",
+        "name": name,
+        "path": "/".join((folder._path if folder else []) + [name]),
+        "members": [],
+    }
+    if folder is not None:
+        rec["folder"] = folder._path
+    _state()["albums"].append(rec)
+    _log(
+        {
+            "op": "create_album",
+            "uuid": rec["uuid"],
+            "name": name,
+            "folder": folder._path if folder else None,
+        }
+    )
+    return Album(rec["uuid"])
+
+
+class PhotosLibrary:
+    def __init__(self):
+        pass
+
+    def album(self, *name, uuid=None, top_level=False):
+        if name:
+            for a in _state()["albums"]:
+                if a["name"] == name[0]:
+                    return Album(a["uuid"])
+            return None
+        return Album(uuid)
+
+    def create_album(self, name, folder=None):
+        return _create_album(name, folder=folder)
+
+    def delete_album(self, album):
+        state = _state()
+        state["albums"] = [a for a in state["albums"] if a["uuid"] != album.uuid]
+        _log({"op": "delete_album", "uuid": album.uuid})
+
+    def make_folders(self, folder_path):
+        if not isinstance(folder_path, list) or not folder_path:
+            raise ValueError("folder_path must be a non-empty list")
+        _log({"op": "make_folders", "path": folder_path})
+        return Folder(folder_path)

--- a/test/fixtures/pyfakes/photoscript/script_loader.py
+++ b/test/fixtures/pyfakes/photoscript/script_loader.py
@@ -1,0 +1,30 @@
+"""Fake script_loader: the two raw AppleScript calls photos_reader.py uses
+(albumPhotes / albumAdd) plus configure_run_script (recorded so tests can
+assert the killall-Photos retry policy is disabled)."""
+
+from . import _album_record, _log
+
+
+def configure_run_script(retry_enabled=None, retries=None, wait_seconds=None):
+    _log({"op": "configure_run_script", "retry_enabled": retry_enabled})
+
+
+def run_script(name, *args):
+    if name == "albumPhotes":
+        rec = _album_record(args[0].split("/")[0])
+        if rec is None:
+            raise RuntimeError(f"fake: no album {args[0]}")
+        return [m + "/L0/001" for m in rec["members"]]
+
+    if name == "albumAdd":
+        rec = _album_record(args[0].split("/")[0])
+        if rec is None:
+            raise RuntimeError(f"fake: no album {args[0]}")
+        ids = [i.split("/")[0] for i in args[1]]
+        for i in ids:
+            if i not in rec["members"]:
+                rec["members"].append(i)
+        _log({"op": "album_add", "album": rec["uuid"], "ids": ids})
+        return [i + "/L0/001" for i in ids]
+
+    raise RuntimeError(f"fake run_script: unhandled handler {name!r}")

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -20,7 +20,7 @@
  *   (or `npx vitest run --config vitest.integration.config.ts`)
  */
 
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { PhotosManager } from "../src/services/photosManager.js";
 
 let mgr: PhotosManager;
@@ -60,6 +60,68 @@ describe("PhotosManager construction", () => {
     expect(typeof m.listAlbums).toBe("function");
     expect(typeof m.listKeywords).toBe("function");
     expect(typeof m.listPersons).toBe("function");
+  });
+
+  it("exposes the write API surface", () => {
+    const m = new PhotosManager();
+    expect(typeof m.createAlbum).toBe("function");
+    expect(typeof m.addToAlbum).toBe("function");
+    expect(typeof m.removeFromAlbum).toBe("function");
+    expect(typeof m.setPhotoMetadata).toBe("function");
+    expect(typeof m.setKeywords).toBe("function");
+  });
+});
+
+// ===========================================================================
+// Write gate — pure, always runs (incl. CI). With the gate closed (the
+// default), every write method must be refused BEFORE any sidecar spawns, so
+// this block is guaranteed side-effect-free: no Photos.app, no AppleScript,
+// no library. The live write path is exercised by test/live-writes.test.ts,
+// which requires an explicit double opt-in.
+// ===========================================================================
+
+describe("write tools are gated off by default", () => {
+  let savedGate: string | undefined;
+
+  beforeAll(() => {
+    savedGate = process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
+    delete process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES;
+  });
+
+  afterAll(() => {
+    if (savedGate !== undefined) {
+      process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES = savedGate;
+    }
+  });
+
+  const gated = /read-only by default/;
+
+  it("createAlbum is refused with the opt-in recipe", async () => {
+    const m = new PhotosManager();
+    await expect(m.createAlbum("Gate Test")).rejects.toThrow(gated);
+    await expect(m.createAlbum("Gate Test")).rejects.toThrow(
+      /APPLE_PHOTOS_MCP_ENABLE_WRITES=1/
+    );
+  });
+
+  it("addToAlbum is refused", async () => {
+    const m = new PhotosManager();
+    await expect(m.addToAlbum("Gate Test", ["0000-0000"])).rejects.toThrow(gated);
+  });
+
+  it("removeFromAlbum is refused", async () => {
+    const m = new PhotosManager();
+    await expect(m.removeFromAlbum("Gate Test", ["0000-0000"])).rejects.toThrow(gated);
+  });
+
+  it("setPhotoMetadata is refused", async () => {
+    const m = new PhotosManager();
+    await expect(m.setPhotoMetadata("0000-0000", { title: "x" })).rejects.toThrow(gated);
+  });
+
+  it("setKeywords is refused", async () => {
+    const m = new PhotosManager();
+    await expect(m.setKeywords("0000-0000", { add: ["x"] })).rejects.toThrow(gated);
   });
 });
 

--- a/test/live-writes.test.ts
+++ b/test/live-writes.test.ts
@@ -1,0 +1,199 @@
+/**
+ * LIVE write-tool tests — these MODIFY the real Photos library and therefore
+ * require an explicit double opt-in:
+ *
+ *   APPLE_PHOTOS_MCP_LIVE_WRITE_TEST=1 pnpm run test:integration -- test/live-writes.test.ts
+ *
+ * (The suite enables APPLE_PHOTOS_MCP_ENABLE_WRITES itself; without the
+ * LIVE_WRITE_TEST flag every test self-skips, so this file is safe in CI and
+ * in a default `test:integration` run.)
+ *
+ * What it does — and undoes — on the live library:
+ *   1. creates the album "MCP Write Test 2.0.0" (and proves create is
+ *      idempotent),
+ *   2. adds two existing photos to it (and proves add is idempotent),
+ *   3. round-trips a keyword (add → verify union semantics → remove) on one
+ *      of them, restoring the original keywords,
+ *   4. round-trips the title on the same photo, restoring the original,
+ *   5. removes one photo from the album (album rebuild — UUID change),
+ *   6. verifies the album is visible to the osxphotos READ path (cache
+ *      invalidation + sidecar re-parse, end-to-end),
+ *   7. afterAll: deletes the test album and force-restores the photo's
+ *      title/keywords via photoscript directly — deletion is deliberately NOT
+ *      an MCP tool, so cleanup goes straight at the backend.
+ *
+ * Requires: macOS, a signed-in Photos library, Full Disk Access, and macOS
+ * Automation permission for Photos (the first write may pop the TCC prompt).
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { PhotosManager } from "../src/services/photosManager.js";
+
+const LIVE = process.env.APPLE_PHOTOS_MCP_LIVE_WRITE_TEST === "1";
+const TEST_ALBUM = "MCP Write Test 2.0.0";
+const TEST_KEYWORD = "mcp-live-write-test";
+const TEST_TITLE = "MCP Live Write Test Title";
+const VENV_PYTHON = resolve(__dirname, "../venv/bin/python3");
+
+let mgr: PhotosManager;
+let ready = false;
+let photoA: string; // keyword/title round-trip target
+let photoB: string;
+let originalKeywords: string[] | null = null;
+let originalTitle: string | null = null;
+let keywordsRestored = false;
+let titleRestored = false;
+let albumUuid: string | null = null;
+
+beforeAll(async () => {
+  if (!LIVE) return;
+  process.env.APPLE_PHOTOS_MCP_ENABLE_WRITES = "1";
+  mgr = new PhotosManager();
+  const health = await mgr.healthCheck();
+  if (!health.ok) return;
+  // Two real, present photos to file into the test album.
+  const result = await mgr.query({ photos: true, newestFirst: true, limit: 10 });
+  const candidates = result.photos.filter((p) => !p.isMissing);
+  if (candidates.length < 2) return;
+  photoA = candidates[0].uuid;
+  photoB = candidates[1].uuid;
+  ready = true;
+}, 180_000);
+
+afterAll(async () => {
+  if (!LIVE || !ready || !existsSync(VENV_PYTHON)) return;
+  // Full cleanup via photoscript DIRECTLY (album deletion is deliberately not
+  // an MCP tool): delete every album named TEST_ALBUM, and force-restore the
+  // photo's title/keywords if the in-test reverts didn't run.
+  const cleanup = `
+import json, sys
+import photoscript
+from photoscript.script_loader import configure_run_script
+configure_run_script(retry_enabled=False)
+spec = json.loads(sys.argv[1])
+lib = photoscript.PhotosLibrary()
+deleted = 0
+album = lib.album(spec["album"])
+while album is not None:
+    lib.delete_album(album)
+    deleted += 1
+    album = lib.album(spec["album"])
+restored = []
+if spec.get("uuid"):
+    p = photoscript.Photo(spec["uuid"])
+    if spec.get("restoreKeywords") is not None:
+        p.keywords = spec["restoreKeywords"]
+        restored.append("keywords")
+    if spec.get("restoreTitle") is not None:
+        p.title = spec["restoreTitle"]
+        restored.append("title")
+print(json.dumps({"deletedAlbums": deleted, "restored": restored}))
+`;
+  const spec = {
+    album: TEST_ALBUM,
+    uuid: photoA ?? null,
+    restoreKeywords: !keywordsRestored && originalKeywords !== null ? originalKeywords : null,
+    restoreTitle: !titleRestored && originalTitle !== null ? originalTitle : null,
+  };
+  const out = execFileSync(VENV_PYTHON, ["-c", cleanup, JSON.stringify(spec)], {
+    encoding: "utf-8",
+    timeout: 300_000,
+  });
+  // Surface the cleanup result in the test output.
+  console.log(`[live-writes cleanup] ${out.trim()}`);
+}, 300_000);
+
+describe("live write tools (opt-in: APPLE_PHOTOS_MCP_LIVE_WRITE_TEST=1)", () => {
+  it("create-album creates the test album", async (ctx) => {
+    if (!ready) ctx.skip();
+    const result = await mgr.createAlbum(TEST_ALBUM);
+    expect(result.album.name).toBe(TEST_ALBUM);
+    expect(result.album.uuid.length).toBeGreaterThan(0);
+    albumUuid = result.album.uuid;
+    // created may be false if a previous aborted run left the album behind —
+    // afterAll deletes it either way.
+  }, 300_000);
+
+  it("create-album is idempotent (same album, created=false)", async (ctx) => {
+    if (!ready) ctx.skip();
+    const again = await mgr.createAlbum(TEST_ALBUM);
+    expect(again.created).toBe(false);
+    expect(again.album.uuid).toBe(albumUuid);
+  }, 300_000);
+
+  it("add-to-album files two photos", async (ctx) => {
+    if (!ready) ctx.skip();
+    const result = await mgr.addToAlbum(TEST_ALBUM, [photoA, photoB]);
+    expect(result.addedCount + result.alreadyPresent.length).toBe(2);
+    expect(result.notFound).toEqual([]);
+  }, 300_000);
+
+  it("add-to-album is idempotent (both reported alreadyPresent)", async (ctx) => {
+    if (!ready) ctx.skip();
+    const again = await mgr.addToAlbum(TEST_ALBUM, [photoA, photoB]);
+    expect(again.addedCount).toBe(0);
+    expect(new Set(again.alreadyPresent)).toEqual(new Set([photoA, photoB]));
+  }, 300_000);
+
+  it("set-keywords adds a keyword with union semantics (existing keywords preserved)", async (ctx) => {
+    if (!ready) ctx.skip();
+    const result = await mgr.setKeywords(photoA, { add: [TEST_KEYWORD] });
+    originalKeywords = result.before;
+    expect(result.added).toEqual([TEST_KEYWORD]);
+    expect(result.after).toEqual([...result.before, TEST_KEYWORD]);
+    expect(result.changed).toBe(true);
+  }, 300_000);
+
+  it("set-keywords removes the keyword, restoring the original list exactly", async (ctx) => {
+    if (!ready) ctx.skip();
+    const result = await mgr.setKeywords(photoA, { remove: [TEST_KEYWORD] });
+    expect(result.removed).toEqual([TEST_KEYWORD]);
+    expect(result.after).toEqual(originalKeywords);
+    keywordsRestored = true;
+  }, 300_000);
+
+  it("set-photo-metadata sets a title and echoes before/after", async (ctx) => {
+    if (!ready) ctx.skip();
+    const result = await mgr.setPhotoMetadata(photoA, { title: TEST_TITLE });
+    originalTitle = result.before.title;
+    expect(result.updated).toEqual(["title"]);
+    expect(result.after.title).toBe(TEST_TITLE);
+    expect(result.before.favorite).toBe(result.after.favorite); // untouched
+  }, 300_000);
+
+  it("set-photo-metadata reverts the title from the echoed before value", async (ctx) => {
+    if (!ready) ctx.skip();
+    const result = await mgr.setPhotoMetadata(photoA, { title: originalTitle ?? "" });
+    expect(result.after.title).toBe(originalTitle ?? "");
+    titleRestored = true;
+  }, 300_000);
+
+  it("remove-from-album removes one photo via the album rebuild (UUID changes)", async (ctx) => {
+    if (!ready) ctx.skip();
+    const result = await mgr.removeFromAlbum(TEST_ALBUM, [photoB]);
+    expect(result.removedCount).toBe(1);
+    expect(result.removed).toEqual([photoB]);
+    expect(result.albumRecreated).toBe(true);
+    expect(result.previousAlbumUuid).toBe(albumUuid);
+    expect(result.album.uuid).not.toBe(albumUuid);
+    albumUuid = result.album.uuid;
+  }, 600_000);
+
+  it("the READ path sees the mutated album (cache invalidation + sidecar re-parse)", async (ctx) => {
+    if (!ready) ctx.skip();
+    // Photos commits via SQLite WAL; osxphotos re-parses on the next read
+    // because the write dropped both caches. Allow a few retries for Photos'
+    // own commit/checkpoint latency.
+    let seen: { title: string; photoCount: number } | undefined;
+    for (let attempt = 0; attempt < 6; attempt++) {
+      const { albums } = await mgr.listAlbums();
+      seen = albums.find((a) => a.title === TEST_ALBUM);
+      if (seen && seen.photoCount === 1) break;
+      await new Promise((r) => setTimeout(r, 2500));
+    }
+    expect(seen, "test album not visible to the osxphotos read path").toBeDefined();
+    expect(seen?.photoCount).toBe(1); // photoA remains; photoB was removed
+  }, 300_000);
+});

--- a/test/output-schema.test.ts
+++ b/test/output-schema.test.ts
@@ -32,7 +32,14 @@ describe("outputSchema contract (real server over stdio)", () => {
     const transport = new StdioClientTransport({
       command: process.execPath,
       args: [SERVER],
-      env: { ...process.env, APPLE_PHOTOS_MCP_NO_AUTO_SETUP: "1" } as Record<string, string>,
+      // ENABLE_WRITES is pinned to "0" (an explicit env var also beats any
+      // config.json on the host machine) so the write-gate assertions below
+      // are deterministic everywhere.
+      env: {
+        ...process.env,
+        APPLE_PHOTOS_MCP_NO_AUTO_SETUP: "1",
+        APPLE_PHOTOS_MCP_ENABLE_WRITES: "0",
+      } as Record<string, string>,
     });
     client = new Client({ name: "outputschema-contract-test", version: "0.0.0" });
     await client.connect(transport);
@@ -87,4 +94,51 @@ describe("outputSchema contract (real server over stdio)", () => {
       void Promise.resolve(call).catch(() => {});
     }
   }, 30_000);
+
+  // --- write tools: registration + gate contract (2.0.0 design decision) ---
+  //
+  // The write tools are ALWAYS REGISTERED — even with the gate closed — and a
+  // gated call returns an isError result carrying the opt-in recipe. This is
+  // deliberate: MCP clients cache the tool list at startup, so hiding the
+  // tools adds no safety (a gate flip needs a restart either way) but destroys
+  // discoverability. These tests pin that contract through a real server.
+
+  const WRITE_TOOLS = [
+    "create-album",
+    "add-to-album",
+    "remove-from-album",
+    "set-photo-metadata",
+    "set-keywords",
+  ];
+
+  it("registers all five write tools even while the gate is closed", async () => {
+    const { tools } = await client.listTools();
+    const names = new Set(tools.map((t) => t.name));
+    for (const tool of WRITE_TOOLS) {
+      expect(names.has(tool), `missing write tool: ${tool}`).toBe(true);
+    }
+  });
+
+  it("every write tool's description carries a Safety: line naming the gate", async () => {
+    const { tools } = await client.listTools();
+    for (const tool of tools.filter((t) => WRITE_TOOLS.includes(t.name))) {
+      expect(tool.description, `${tool.name} description`).toMatch(/Safety:/);
+      expect(tool.description, `${tool.name} description`).toContain(
+        "APPLE_PHOTOS_MCP_ENABLE_WRITES"
+      );
+    }
+  });
+
+  it("a gated write call returns a clear isError result with the opt-in recipe (not a protocol error)", async () => {
+    const result = (await client.callTool({
+      name: "create-album",
+      arguments: { name: "Gate Contract Test" },
+    })) as { isError?: boolean; content?: Array<{ type: string; text?: string }> };
+
+    expect(result.isError).toBe(true);
+    const text = result.content?.map((c) => c.text ?? "").join("\n") ?? "";
+    expect(text).toMatch(/read-only by default/);
+    expect(text).toContain("APPLE_PHOTOS_MCP_ENABLE_WRITES=1");
+    expect(text).toContain("config.json");
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary

**First release that can modify the Photos library** — implements review findings **NF-3** (album writes) and **NF-4** (metadata writes) as five opt-in tools, MAJOR-bumped to **2.0.0** because the unconditional read-only guarantee becomes a (default-on) opt-out. **Nothing changes for existing users:** without `APPLE_PHOTOS_MCP_ENABLE_WRITES=1`, every write tool returns a clear opt-in error and the server behaves exactly like 1.x.

| Tool | Shape | Notes |
|------|-------|-------|
| `create-album` | `{name, folder?}` | Idempotent — existing album returned with `created:false`; `/`-separated folder path created as needed |
| `add-to-album` | `{album, uuid[1..100]}` | Idempotent; per-UUID `added`/`alreadyPresent`/`notFound` |
| `remove-from-album` | `{album, uuid[1..100]}` | Album membership ONLY — never deletes photos; rebuilds the album (see below) |
| `set-photo-metadata` | `{uuid, title?, description?, favorite?}` | Writes only the fields passed; echoes before/after for undo |
| `set-keywords` | `{uuid, add?, remove?}` | **Union semantics** — read-merge-write; unmentioned keywords always preserved |

## Gate design decision: always-register + gated error (not conditional registration)

The write tools are **registered unconditionally** and return a self-explanatory error while disabled. Rationale:

- MCP clients cache the tool list at server startup, so conditional registration adds **no security** — flipping the env requires a restart either way.
- It **costs discoverability**: an agent that can't see the tools can only say "impossible"; an agent that gets the gated error can relay the exact opt-in recipe (env var, config.json path, restart).
- The gate is enforced in **two layers**: `PhotosManager.runWrite()` (before anything spawns) and inside the Python sidecar (defense in depth for direct CLI invocation). `doctor` gained a sixth check reporting the gate state — plus, when enabled, photoscript importability and Photos.app presence, and a note that macOS Automation permission arrives via a one-time prompt on the first write (deliberately not probed: probing would trigger the prompt).

## Safety design (the core of the release)

- **No deletion capability of any kind** — no tool deletes photos, albums, or folders. The documented deletion path is the album-quarantine pattern (pairs with `find-duplicates`): file extras into an album, user reviews/deletes in Photos.app with the 30-day Recently Deleted net.
- **Explicit targets only** — UUIDs/names required, validated to exist before any mutation (clear not-found errors / per-UUID `notFound` lists); no "current selection", no wildcard ops; 100-UUID batch caps.
- **Reversibility** — metadata writes echo before/after; `set-keywords` merges rather than replaces; album adds are idempotent.
- **`remove-from-album` feasibility**: photoscript **does** support removal (`Album.remove`/`remove_by_id`), but Photos' AppleScript dictionary has no remove verb, so removal is implemented (as photoscript does internally, but with bulk-id calls instead of per-photo AppleScript round-trips) by **rebuilding the album**: create replacement → copy kept photos → delete original → rename. The album **UUID changes** (`previousAlbumUuid` → `album.uuid` in the response) and manual sort order is lost — documented in the tool description, README, and LIMITATIONS.md. A call matching no members skips the rebuild entirely; a mid-rebuild failure deletes only the scratch album and leaves the original untouched.
- **Never kills Photos.app** — photoscript's default retry policy runs `killall Photos` on AppleScript timeout; it's disabled (`configure_run_script(retry_enabled=False)`).
- **Cache coherence** — after every write, both the Node catalog cache and the sidecar's resident PhotosDB are **force-invalidated** instead of trusting the `Photos.sqlite` mtime bust (Photos commits through SQLite WAL, so the mtime can lag a write). Verified live: a `remove-from-album` was visible to the osxphotos read path on the next `list-albums`.
- Writes target the library **currently open in Photos.app** (AppleScript constraint) — write tools take no `library` param, documented everywhere.

## Backend

[photoscript](https://github.com/RhetTbull/photoscript) 0.5.3 (already in the venv as an osxphotos dep; now an explicit pinned entry in `requirements.txt`), every API verified against the installed version by introspection. Write commands flow through the same argparse+`--serve` sidecar protocol and serial gate as reads; photoscript is imported lazily so read-only users never load it.

## Tests (all green)

- **Unit (245)** — gate matrix (`1`/`true`/`0`/`false`/unset), gated-refusal before spawn for all five manager methods, argv construction (incl. dash-safe `--flag=value`), cache force-clear on success/failure/not-on-gated, doctor writes check (disabled/enabled/photoscript-missing/busy).
- **Hermetic Python handler tests** — the real `photos_reader.py` runs one-shot against a **fake photoscript/osxphotos** (`test/fixtures/pyfakes/`, PYTHONPATH-shadowed, mutation-logged): sidecar-side gate, union merges, create idempotency, add split (added/alreadyPresent/notFound), the exact remove rebuild sequence (create→add→delete→rename, only keepers copied, original album deleted — never a photo), validate-first errors, killall-retry disabled.
- **MCP round-trip contract** (`test/output-schema.test.ts`, real built server over stdio) — all five tools registered while gated, Safety: lines present, gated call returns `isError` + the opt-in recipe.
- **Integration** (CI-safe) — with writes disabled, every write method refused before any spawn.
- **Live suite** (`test/live-writes.test.ts`, double-gated behind `APPLE_PHOTOS_MCP_LIVE_WRITE_TEST=1`) — ran green against the real ~31k-photo library on robs-homeoffice-mbpromax: create + idempotent re-create, add 2 photos + idempotent re-add, keyword add/remove round-trip (original list restored exactly), title set + revert from the echoed before-value, remove-from-album (UUID change verified), read-path visibility check, then **full cleanup** (test album deleted via photoscript directly — deletion is deliberately not an MCP tool). No TCC prompt blocked (Automation already granted for this host).

## Docs

README (new prominent **Write tools (opt-in)** section + Tool Reference entries + config/env docs + patterns), CHANGELOG (headline: read-only by default, unchanged unless opted in), CLAUDE.md (write workflow + album-quarantine pattern), SKILL.md ×3 (byte-identical), docs/LIMITATIONS.md, plugin manifests. QUERY-GUIDE untouched.

## Gates

lint ✅ format:check ✅ typecheck ✅ test (245) ✅ test:integration (33+10 gated-skips) ✅ build ✅ `npm pack --dry-run` ✅ (11 files, photos_reader.py + requirements.txt shipped) — bundle greps confirm the gate env var and all five commands in `build/index.js`.