### PR TITLE
fix(doctor): classify osxphotos "Error copying …/Photos.sqlite" as an FDA denial (#37)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-photos-mcp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Apple Photos integration for Claude Code via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -11,7 +11,7 @@
     {
       "name": "apple-photos",
       "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only)",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **`doctor` and per-tool errors now recognize osxphotos' `Error copying …/Photos.sqlite to /tmp/…` as a Full Disk Access denial** (#37). osxphotos copies the live library database to a temp dir before opening it; when the host process lacks FDA, macOS denies the read of the source and osxphotos surfaces a generic copy failure containing none of the usual permission wording. Previously `doctor` classified it as `full_disk_access: warn "did not look permission-related"`, actively steering users away from the real cause. The permission-error heuristic (now shared between `doctor` and `photosManager` in `src/utils/permissionErrors.ts`) matches this message, so `doctor` reports a Full Disk Access failure with remediation and per-tool errors append the FDA guidance.
+
+### Documentation
+- **`docs/FULL-DISK-ACCESS.md`** — documents the `Error copying …/Photos.sqlite` failure form, and adds a "the host app may be a *nested* bundle" gotcha (#37): a Claude Code-spawned MCP server's file access is attributed to the per-version `~/Library/Application Support/Claude/claude-code/<version>/claude.app` bundle (which needs its own FDA grant and silently resets on Claude auto-update — the tell is a new lowercase "claude" row in the FDA list), not to `/Applications/Claude.app`.
+
 ## [2.1.0] - 2026-07-10
 
 **Roadmap close-out: date fixing, imports, the Photos.app selection bridge, ML/social metadata, and GPS-radius search.** The two new write tools ride the existing `APPLE_PHOTOS_MCP_ENABLE_WRITES` gate — the server remains read-only by default, and still nothing can delete a photo.

--- a/build/index.js
+++ b/build/index.js
@@ -22152,6 +22152,14 @@ async function checkDependencies() {
   }
 }
 
+// src/utils/permissionErrors.ts
+function looksLikePermissionError(message) {
+  if (/not permitted|permission|full disk|denied|unable to open/i.test(message)) {
+    return true;
+  }
+  return /error copying\b.*photos\.sqlite/is.test(message);
+}
+
 // src/utils/exportPath.ts
 import { existsSync as existsSync2, realpathSync } from "node:fs";
 import { homedir } from "node:os";
@@ -22226,7 +22234,7 @@ function assertWritesEnabled(env = process.env) {
 
 // src/services/photosManager.ts
 function augmentPermissionError(message) {
-  if (/not permitted|permission|full disk|denied|unable to open/i.test(message)) {
+  if (looksLikePermissionError(message)) {
     return `${message}
 
 This looks like a macOS permission issue: ${FDA_REMEDIATION}`;
@@ -22702,9 +22710,6 @@ function withErrorHandling(handler, prefix) {
 // src/tools/doctor.ts
 import { existsSync as existsSync4 } from "node:fs";
 var PHOTOS_APP_PATH = "/System/Applications/Photos.app";
-function looksLikePermissionError(message) {
-  return /not permitted|permission|full disk|denied|unable to open/i.test(message);
-}
 async function runDoctor(manager2) {
   const checks = [];
   try {

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/docs/FULL-DISK-ACCESS.md
+++ b/docs/FULL-DISK-ACCESS.md
@@ -69,10 +69,45 @@ level and tools fail with a permissions-flavored error. Typical messages:
 
 - `operation not permitted`
 - `unable to open database file`
+- `Error copying …/Photos Library.photoslibrary/database/Photos.sqlite to /tmp/osxphotos_…/Photos.sqlite`
 - a generic "Library not found" / permission error from `health-check`
+
+The `Error copying …/Photos.sqlite to /tmp/…` form is the most misleading: osxphotos
+copies the live library database to a temp directory before opening it, and when
+the host process lacks FDA, macOS denies the **read of the source** — surfaced as a
+generic copy failure with no "permission" wording. It is still an FDA denial. (As of
+v2.1.1 `doctor` classifies this message as a Full Disk Access failure and points here
+rather than reporting "did not look permission-related".)
 
 These are macOS denying access, not a bug in the server. The fix is always the
 same: grant FDA to the host app and **fully restart it** (see above).
+
+### Gotcha: the "host app" for a Claude-spawned server may be a *nested* bundle
+
+If you granted Full Disk Access to `/Applications/Claude.app` (or to your
+terminal), fully restarted, even rebooted — and osxphotos-backed tools **still**
+fail with `Error copying …/Photos.sqlite …` while the exact same
+`osxphotos.PhotosDB()` call succeeds when you run the venv Python directly — the
+grant almost certainly landed on the wrong identity.
+
+macOS attributes a locally-spawned MCP subprocess's file access to the
+**responsible process**, which is not always the app icon you clicked:
+
+- **Claude Code (CLI/desktop Code tab)** spawns MCP servers under a **per-version
+  nested helper bundle**, not `/Applications/Claude.app`. Look for it at
+  `~/Library/Application Support/Claude/claude-code/<version>/claude.app`. This
+  bundle needs its **own** FDA grant, and it **silently resets on every Claude
+  auto-update** — the tell is a new, un-checked lowercase **"claude"** row
+  appearing in the Full Disk Access list.
+- **A terminal-launched server** is attributed to the terminal app
+  (Terminal/iTerm/VS Code), not to `node`.
+
+Fix it: open **System Settings → Privacy & Security → Full Disk Access**, look for
+a **"claude"** entry (distinct from "Claude") or add the nested
+`…/claude-code/<version>/claude.app` bundle via **+**, toggle it **on**, then
+restart the MCP server (a fresh session, or quit/relaunch the host). If it worked
+before and broke after an update, re-check this list first — the grant was reset,
+not lost for good.
 
 ## Note: exporting iCloud-only originals also needs Photos automation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos-mcp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Photos - query, search, export, and inspect the macOS Photos library via Claude and other AI assistants, plus opt-in album/metadata write tools (read-only by default)",
   "type": "module",

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -229,6 +229,27 @@ describe("runDoctor", () => {
     );
   });
 
+  it("flags Full Disk Access when osxphotos fails to copy Photos.sqlite (FDA denial in disguise)", async () => {
+    checkMock.mockResolvedValue({ ok: true, message: "osxphotos 0.76.1 available" });
+    const manager = fakeManager(() => {
+      throw new Error(
+        "Error copying/Users/x/Pictures/Photos Library.photoslibrary/database/Photos.sqlite " +
+          "to /tmp/osxphotos_abcd1234/Photos.sqlite"
+      );
+    });
+
+    const report = await runDoctor(manager);
+
+    expect(report.healthy).toBe(false);
+
+    const lib = report.checks.find((c) => c.name === "photos_library");
+    expect(lib?.status).toBe("fail");
+
+    const fda = report.checks.find((c) => c.name === "full_disk_access");
+    expect(fda?.status).toBe("fail");
+    expect(fda?.detail).toMatch(/Full Disk Access/i);
+  });
+
   it("warns (not fails) on full_disk_access when the library error is unrelated to permissions", async () => {
     checkMock.mockResolvedValue({ ok: true, message: "osxphotos 0.76.1 available" });
     const manager = fakeManager(() => {

--- a/src/__tests__/permissionErrors.test.ts
+++ b/src/__tests__/permissionErrors.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { looksLikePermissionError } from "../utils/permissionErrors.js";
+
+describe("looksLikePermissionError", () => {
+  it("recognizes explicit macOS denials", () => {
+    expect(looksLikePermissionError("Operation not permitted")).toBe(true);
+    expect(looksLikePermissionError("unable to open database file")).toBe(true);
+    expect(looksLikePermissionError("access denied")).toBe(true);
+    expect(looksLikePermissionError("Full Disk Access required")).toBe(true);
+  });
+
+  it("recognizes osxphotos' 'Error copying …/Photos.sqlite' as an FDA denial", () => {
+    expect(
+      looksLikePermissionError(
+        "Error copying/Users/x/Pictures/Photos Library.photoslibrary/database/Photos.sqlite " +
+          "to /tmp/osxphotos_abcd1234/Photos.sqlite"
+      )
+    ).toBe(true);
+    // Space after "Error copying" and mixed casing still match.
+    expect(
+      looksLikePermissionError("error copying /path/Photos.sqlite to /tmp/x/Photos.sqlite")
+    ).toBe(true);
+  });
+
+  it("does not misclassify unrelated errors", () => {
+    expect(looksLikePermissionError("library locked")).toBe(false);
+    expect(looksLikePermissionError("timeout after 60000ms")).toBe(false);
+    // A copy error that is not about Photos.sqlite is not FDA-flagged.
+    expect(looksLikePermissionError("Error copying export.jpg to /tmp/out.jpg")).toBe(false);
+  });
+});

--- a/src/services/photosManager.ts
+++ b/src/services/photosManager.ts
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 import { runPhotosReader, sidecarBusy, isVenvReady } from "../utils/python.js";
 import type { SidecarProgress } from "../utils/sidecarClient.js";
 import { FDA_REMEDIATION } from "../utils/docsUrls.js";
+import { looksLikePermissionError } from "../utils/permissionErrors.js";
 import { resolveExportDest, resolveImportSource } from "../utils/exportPath.js";
 import { assertWritesEnabled } from "../utils/writeGate.js";
 import type {
@@ -31,11 +32,13 @@ import type {
 
 /**
  * macOS denies reading the Photos library without Full Disk Access; osxphotos
- * then surfaces a low-level error like "unable to open database file". Append
- * actionable guidance so the failure is self-service rather than cryptic.
+ * then surfaces a low-level error — sometimes "unable to open database file",
+ * sometimes a generic "Error copying …/Photos.sqlite to /tmp/…" (a denied read
+ * of the source DB during osxphotos' temp-copy step). Append actionable
+ * guidance so the failure is self-service rather than cryptic.
  */
 function augmentPermissionError(message: string): string {
-  if (/not permitted|permission|full disk|denied|unable to open/i.test(message)) {
+  if (looksLikePermissionError(message)) {
     return `${message}\n\nThis looks like a macOS permission issue: ${FDA_REMEDIATION}`;
   }
   return message;

--- a/src/tools/doctor.ts
+++ b/src/tools/doctor.ts
@@ -21,6 +21,7 @@ import {
   sidecarBusy,
 } from "../utils/python.js";
 import { FDA_REMEDIATION, TROUBLESHOOTING_URL, WRITE_TOOLS_URL } from "../utils/docsUrls.js";
+import { looksLikePermissionError } from "../utils/permissionErrors.js";
 import { writesEnabled, WRITES_ENV } from "../utils/writeGate.js";
 
 /** Where macOS installs Photos.app (the write tools drive it via AppleScript). */
@@ -35,11 +36,6 @@ export interface DoctorCheck {
 export interface DoctorReport {
   healthy: boolean;
   checks: DoctorCheck[];
-}
-
-/** Heuristic: does this error look like a permission / Full Disk Access failure? */
-function looksLikePermissionError(message: string): boolean {
-  return /not permitted|permission|full disk|denied|unable to open/i.test(message);
 }
 
 /**

--- a/src/utils/permissionErrors.ts
+++ b/src/utils/permissionErrors.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared detection for osxphotos errors that are really macOS Full Disk Access
+ * (TCC) denials in disguise. Both the doctor tool and the per-tool error
+ * augmentation use this, so the two can never disagree about whether a failure
+ * is permission-related.
+ *
+ * @module utils/permissionErrors
+ */
+
+/**
+ * Does this error look like a permission / Full Disk Access failure?
+ *
+ * Two families are recognized:
+ *
+ * 1. **Explicit denials** — "operation not permitted", "unable to open
+ *    database file", etc. These name the permission directly.
+ *
+ * 2. **osxphotos copy failures** — `Error copying …/Photos.sqlite to
+ *    /tmp/osxphotos_…/Photos.sqlite`. osxphotos copies the live Photos
+ *    database to a temp dir before opening it; when the host process lacks FDA,
+ *    macOS denies the *read* of the source and osxphotos surfaces it as a
+ *    generic copy error with none of the words in family (1). Left
+ *    unclassified, `doctor` reports "did not look permission-related", which
+ *    actively sends users away from the real cause (FDA on the host process,
+ *    including the nested-bundle attribution gotcha — see FULL-DISK-ACCESS.md).
+ *    On a machine where the same copy succeeds standalone, this message inside
+ *    the MCP child process is overwhelmingly an FDA denial, so we treat it as
+ *    one.
+ */
+export function looksLikePermissionError(message: string): boolean {
+  if (/not permitted|permission|full disk|denied|unable to open/i.test(message)) {
+    return true;
+  }
+  // osxphotos "Error copying <library>/…/Photos.sqlite to <tmp>/…" — a failed
+  // copy of the protected Photos database is an FDA denial in disguise.
+  return /error copying\b.*photos\.sqlite/is.test(message);
+}


### PR DESCRIPTION
## Summary

Fixes the misleading diagnostic reported in #37: an FDA-denied host process makes osxphotos fail its temp-copy of the Photos database with a generic `Error copying …/Photos.sqlite to /tmp/osxphotos_…/Photos.sqlite` — a message with none of the usual permission wording. `doctor` was classifying it as `full_disk_access: warn "did not look permission-related"`, actively steering users away from the real cause (the reporter spent hours ruling out FDA because of exactly this).

## Changes

- **`src/utils/permissionErrors.ts`** (new) — single shared `looksLikePermissionError()` used by both `doctor` and `photosManager` (they previously duplicated the regex), extended to match the `Error copying …Photos.sqlite` copy-failure signature.
- **`doctor`** now reports a **Full Disk Access failure** with remediation on this message instead of a non-committal warn.
- **Per-tool errors** append the FDA guidance for this message too.
- **`docs/FULL-DISK-ACCESS.md`** — documents the copy-failure form, and adds a **nested-bundle attribution gotcha**: a Claude Code-spawned MCP server's file access is attributed to the per-version `~/Library/Application Support/Claude/claude-code/<version>/claude.app` bundle (needs its own FDA grant; silently resets on Claude auto-update — tell is a new lowercase "claude" row in the FDA list), not `/Applications/Claude.app`. This is the real environmental cause for the reporter, who granted FDA to the visible app.
- Version bump 2.1.0 → 2.1.1 + CHANGELOG.

## Tests

- New `permissionErrors.test.ts` (explicit denials, the copy-failure signature, and non-misclassification of unrelated copy/lock errors).
- New `doctor` case asserting the copy-failure message yields `full_disk_access: fail` with remediation.
- Full suite green (288 tests), typecheck/lint/format/build all pass; committed bundle rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)