### PR TITLE
docs(fda): document node-binary TCC attribution (#37 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Documentation
+- **`docs/FULL-DISK-ACCESS.md`** — adds a "still failing after granting every host app?" section (#37 follow-up): on at least one confirmed setup, TCC attributed the FDA check directly to the `node` binary itself, not to any wrapper app — responsibility never climbed past `node` to see those grants. Documents the definitive diagnostic (`log stream --predicate 'subsystem == "com.apple.TCC"'`, reading the `Resp:` process from the denial) and the fix (grant FDA to the exact `node` path the log names), plus the ad-hoc-vs-Developer-ID-signature note on why the grant may or may not survive a Node upgrade.
+
+## [2.1.1] - 2026-07-19
+
 ### Fixed
 - **`doctor` and per-tool errors now recognize osxphotos' `Error copying …/Photos.sqlite to /tmp/…` as a Full Disk Access denial** (#37). osxphotos copies the live library database to a temp dir before opening it; when the host process lacks FDA, macOS denies the read of the source and osxphotos surfaces a generic copy failure containing none of the usual permission wording. Previously `doctor` classified it as `full_disk_access: warn "did not look permission-related"`, actively steering users away from the real cause. The permission-error heuristic (now shared between `doctor` and `photosManager` in `src/utils/permissionErrors.ts`) matches this message, so `doctor` reports a Full Disk Access failure with remediation and per-tool errors append the FDA guidance.
 

--- a/docs/FULL-DISK-ACCESS.md
+++ b/docs/FULL-DISK-ACCESS.md
@@ -109,6 +109,41 @@ restart the MCP server (a fresh session, or quit/relaunch the host). If it worke
 before and broke after an update, re-check this list first — the grant was reset,
 not lost for good.
 
+### Still failing after granting every host app? Check whether TCC attributed it to `node` itself
+
+Every fix above assumes responsibility climbs from the subprocess up to *some*
+app — Claude Desktop, the nested Code bundle, or your terminal. On at least one
+confirmed setup it didn't: TCC attributed the check directly to the `node`
+binary, and none of the wrapper-app grants ever touched it, because
+responsibility never climbed past `node` to see them.
+
+Don't guess between the theories above — the macOS unified log is
+authoritative. Reproduce the failure while streaming:
+
+```
+log stream --style compact --predicate 'subsystem == "com.apple.TCC"' --info
+```
+
+Look for a line like:
+
+```
+Handling access request to kTCCServiceSystemPolicyAllFiles,
+from Sub:{/usr/local/bin/node}
+Resp:{TCCDProcess: identifier=node, pid=…, responsible_path=/usr/local/bin/node, binary_path=/usr/local/bin/node},
+ReqResult(Auth Right: Denied …)
+```
+
+If `Resp:` names `node` (not `claude.app`, not your terminal), grant FDA to the
+**node binary itself**: **+** → ⌘⇧G → type the exact path from `responsible_path`
+above (commonly `/usr/local/bin/node`, `/opt/homebrew/bin/node`, or a
+pinned-runtime path) → toggle on → fully quit and relaunch the host app.
+
+A stable, Developer-ID-signed Node build (check `codesign -dv $(which node)` —
+look for a real `TeamIdentifier`, not `flags=0x2(adhoc)`) keeps this grant
+across Node upgrades. An ad-hoc-signed build (common with some Homebrew
+formulae) gets a new code identity on every rebuild, so the grant can need
+re-doing after `brew upgrade`.
+
 ## Note: exporting iCloud-only originals also needs Photos automation
 
 Full Disk Access covers reading and querying the library, and exporting any


### PR DESCRIPTION
Follow-up to #37: a user confirmed via `log stream --predicate 'subsystem == "com.apple.TCC"'` that TCC attributed the FDA denial directly to the `node` binary, not any wrapper app. Adds that diagnostic + fix to `docs/FULL-DISK-ACCESS.md`, and promotes the CHANGELOG's `[Unreleased]` entries to a dated `[2.1.1]` section matching what's already on npm. Docs-only, no version bump needed.