### PR TITLE
docs(skills): add sync-skills drift guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Root skills/ is canonical; codex/skills/ and .antigravity-plugin/skills/
+      # are generated copies. Fails when they drift (fix: pnpm run sync:skills).
+      - name: Verify skill copies match skills/
+        run: node scripts/sync-skills.mjs --check
+
       - name: Run linter
         run: pnpm run lint
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ When adding a new MCP tool:
 2. **Implement the method** in `src/services/photosManager.ts`.
 3. **Add the command** to the Python sidecar `src/utils/photos_reader.py`.
 4. **Add type definitions** in `src/types.ts`.
-5. **Write tests** and **update** `README.md` + `CHANGELOG.md`.
+5. **Write tests** and **update** `README.md` + `CHANGELOG.md`. If the skill guidance changed, edit `skills/apple-photos/SKILL.md` (the canonical copy) and run `pnpm run sync:skills` — the `codex/` and `.antigravity-plugin/` copies are generated from it and CI fails if they drift.
 
 ## Sidecar Guidelines
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "format": "prettier --write src",
     "format:check": "prettier --check src",
     "typecheck": "tsc --noEmit",
+    "sync:skills": "node scripts/sync-skills.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/sync-skills.mjs
+++ b/scripts/sync-skills.mjs
@@ -1,0 +1,69 @@
+// Root skills/ is the canonical copy; the per-surface duplicates
+// (codex/skills/, .antigravity-plugin/skills/) are generated from it and must
+// never be edited directly. (.agents/plugins/marketplace.json sources ./codex,
+// and .hermes-plugin carries no skill copy — syncing codex covers every other
+// surface.)
+//
+//   node scripts/sync-skills.mjs          overwrite the copies from skills/
+//   node scripts/sync-skills.mjs --check  exit 1 on any drift (CI gate)
+//
+// Edit skills/**, run `pnpm run sync:skills`, and commit all three trees.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const CANONICAL = "skills";
+const TARGETS = ["codex/skills", ".antigravity-plugin/skills"];
+
+const check = process.argv.includes("--check");
+const canonicalFiles = listFiles(path.join(root, CANONICAL));
+const drifted = [];
+
+for (const target of TARGETS) {
+  const targetRoot = path.join(root, target);
+  // Files present in a target but absent from skills/ are orphans from a
+  // removed or renamed skill — stale content, so they count as drift too.
+  for (const rel of listFiles(targetRoot)) {
+    if (!canonicalFiles.includes(rel)) {
+      drifted.push(`${path.join(target, rel)} (orphan; not in ${CANONICAL}/)`);
+      if (!check) fs.rmSync(path.join(targetRoot, rel));
+    }
+  }
+  for (const rel of canonicalFiles) {
+    const source = path.join(root, CANONICAL, rel);
+    const dest = path.join(targetRoot, rel);
+    if (
+      fs.existsSync(dest) &&
+      fs.readFileSync(source).equals(fs.readFileSync(dest))
+    ) {
+      continue;
+    }
+    drifted.push(path.join(target, rel));
+    if (!check) {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.copyFileSync(source, dest);
+    }
+  }
+}
+
+if (drifted.length === 0) {
+  console.log(`skill copies in sync with ${CANONICAL}/: ${TARGETS.join(", ")}`);
+} else if (check) {
+  console.error(`skill copies have drifted from ${CANONICAL}/:`);
+  for (const file of drifted) console.error(`  ${file}`);
+  console.error("Run 'pnpm run sync:skills' and commit the result.");
+  process.exit(1);
+} else {
+  console.log(`synced from ${CANONICAL}/:`);
+  for (const file of drifted) console.log(`  ${file}`);
+}
+
+function listFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.relative(dir, path.join(entry.parentPath, entry.name)))
+    .sort();
+}


### PR DESCRIPTION
Ports the SKILL.md copy-sync guard from apple-notes-mcp (sweetrb/apple-notes-mcp#88) to photos.

- Root `skills/apple-photos/SKILL.md` is canonical; `scripts/sync-skills.mjs` (`pnpm run sync:skills`) regenerates the `codex/` + `.antigravity-plugin/` copies from it and removes orphans.
- A new `ci.yml` test-job step runs `node scripts/sync-skills.mjs --check`, so any copy drift fails PRs (same pattern as the committed-bundle verify step).
- CONTRIBUTING's Adding New Tools checklist documents the flow.

All three photos copies were already byte-identical, so this PR adds only the guard — zero SKILL.md content changes. (`.agents/plugins/marketplace.json` sources `./codex`; `.hermes-plugin` has no skill copy — the script's coverage is complete for photos too.)

Docs/tooling only — no shipped code, no version bump (version-guard exempt: package.json change is scripts-map only, dependencies untouched).