### PR TITLE
ci: bulletproof hardening (audit 2026-07-20)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-photos-mcp",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Apple Photos integration for Claude Code via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -11,7 +11,7 @@
     {
       "name": "apple-photos",
       "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only)",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,15 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      pip:
+        patterns: ["*"]
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# RENAME HAZARD: `name: CI` is publish.yml's workflow_run trigger key, and the
+# `test` job's matrix produces required branch-protection contexts
+# `test (22)` / `test (24)`. Renaming either silently severs publishing/merging.
 name: CI
 
 on:
@@ -27,19 +30,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -57,22 +60,69 @@ jobs:
       - name: Check formatting
         run: pnpm run format:check
 
+      - name: Verify plugin manifests match package.json version
+        run: node scripts/sync-plugin-version.mjs --check
+
       - name: Type check
         run: pnpm run typecheck
 
       - name: Run tests with coverage
         run: pnpm run test:coverage
 
+      - name: Upload coverage reports
+        if: matrix.node-version == 22
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+        continue-on-error: true
+
       - name: Build
         run: pnpm run build
 
       - name: Verify committed build/ matches source
         run: |
+          UNTRACKED=$(git status --porcelain --ignored -- build/ | grep -E '^(\?\?|!!)' || true)
+          if [ -n "$UNTRACKED" ]; then
+            echo "::error::Build emitted files into build/ that are not tracked:"; echo "$UNTRACKED"
+            exit 1
+          fi
           if ! git diff --quiet build/; then
             echo "::error::build/ is out of date. Run 'pnpm run build' locally and commit the changes."
             git --no-pager diff --stat build/
             exit 1
           fi
+
+  # The committed bundle is what npm and marketplace users actually run — prove
+  # it boots by itself (no node_modules, no pnpm) on the OLDEST supported Node
+  # (engines.node >= 20), not just that it rebuilds byte-identically.
+  bundle-boots:
+    name: bundle-boots (standalone, Node 20)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+      - name: Boot the committed bundle standalone (no node_modules, Node 20)
+        # The sidecar .py is not copied: the initialize handshake never spawns
+        # it. macOS runners have no `timeout` binary — the perl alarm survives
+        # exec and kills a hung server after 30s.
+        run: |
+          set -euo pipefail
+          DIR=$(mktemp -d)
+          cp package.json "$DIR/"
+          cp -R build "$DIR/build"
+          cd "$DIR"
+          RESP=$(printf '%s\n' \
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci-boot","version":"0"}}}' \
+            | perl -e 'alarm 30; exec @ARGV' node build/index.js | head -1)
+          echo "$RESP" | node -e '
+            let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+              const j=JSON.parse(s);
+              if(!j.result||!j.result.serverInfo||!j.result.serverInfo.version){console.error("no serverInfo in initialize response");process.exit(1)}
+              console.log("bundle boots standalone on Node 20: v"+j.result.serverInfo.version);
+            })'
 
   # Integration suite (opt-in, real Photos library). On CI the runner has no
   # signed-in Photos library, so the live tests self-skip; the pure tests still
@@ -83,19 +133,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: "pnpm"
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,18 +10,23 @@ permissions:
   contents: read
 jobs:
   analyze:
-    name: Analyze (javascript-typescript)
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       security-events: write
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # python covers the osxphotos sidecar (src/utils/photos_reader.py).
+        language: [javascript-typescript, python]
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
-          languages: javascript-typescript
+          languages: ${{ matrix.language }}
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Enable auto-merge for dev-deps and github-actions
         if: ${{ steps.meta.outputs.package-ecosystem == 'github_actions' || steps.meta.outputs.dependency-type == 'direct:development' }}
         run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/dependabot-rebuild.yml
+++ b/.github/workflows/dependabot-rebuild.yml
@@ -76,7 +76,7 @@ jobs:
       built_from: ${{ steps.head.outputs.sha }}
     steps:
       - name: Checkout PR head branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           persist-credentials: false
@@ -105,7 +105,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.guard.outputs.skip != 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: "pnpm"
@@ -158,9 +158,12 @@ jobs:
     steps:
       - name: Checkout PR head branch
         if: needs.rebuild.outputs.changed == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref || github.ref_name }}
+          # Full history: the auto-bump step below compares package.json's
+          # version at the fork point (merge-base with origin/main).
+          fetch-depth: 0
 
       - name: Abort if the branch moved since the rebuild
         if: needs.rebuild.outputs.changed == 'true'
@@ -191,6 +194,52 @@ jobs:
         with:
           name: rebuilt-bundle
           path: build/
+
+      - name: Auto-bump patch version for shipped-byte change
+        # version-guard now treats build/** as shipped bytes, so every
+        # bundle-changing Dependabot PR needs a version bump — without this
+        # auto-bump they would all fail the guard (and an un-bumped merge
+        # would silently never publish). Deliberately NO pnpm and NO install
+        # here: dependency lifecycle code must never run in the write-token
+        # job (token-split invariant) — plain `node -e` edits plus the
+        # repo-owned, dependency-free sync script only. The changes ride the
+        # existing "[dependabot skip]" commit below.
+        if: needs.rebuild.outputs.changed == 'true'
+        run: |
+          git fetch --no-tags --quiet origin +refs/heads/main:refs/remotes/origin/main
+          BASE_SHA="$(git merge-base origin/main HEAD)"
+          basev="$(git show "${BASE_SHA}:package.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).version))')"
+          headv="$(node -p "require('./package.json').version")"
+          if [ "$basev" != "$headv" ]; then
+            echo "Version already bumped on this branch (${basev} -> ${headv}) — skipping auto-bump."
+            exit 0
+          fi
+          node -e '
+            const fs = require("fs");
+            const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+            const p = pkg.version.split(".");
+            p[2] = String(Number(p[2]) + 1);
+            pkg.version = p.join(".");
+            fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+            console.log("Auto-bumped version to " + pkg.version);
+          '
+          node scripts/sync-plugin-version.mjs
+          node -e '
+            const fs = require("fs");
+            const v = require("./package.json").version;
+            const date = new Date().toISOString().slice(0, 10);
+            const entry = "## [" + v + "] - " + date + "\n\n### Changed\n\n- Dependency bump via Dependabot; committed bundle rebuilt. (automated)\n";
+            let c = fs.readFileSync("CHANGELOG.md", "utf8");
+            const m = c.match(/^## \[Unreleased\].*$/m);
+            if (m) {
+              const i = c.indexOf(m[0]) + m[0].length;
+              c = c.slice(0, i) + "\n\n" + entry + c.slice(i);
+            } else {
+              c = entry + "\n" + c;
+            }
+            fs.writeFileSync("CHANGELOG.md", c);
+          '
+          git add package.json CHANGELOG.md build .claude-plugin .agents codex .hermes-plugin .antigravity-plugin 2>/dev/null || true
 
       - name: Commit and push the rebuilt bundle
         if: needs.rebuild.outputs.changed == 'true'

--- a/.github/workflows/dependabot-rebuild.yml
+++ b/.github/workflows/dependabot-rebuild.yml
@@ -161,8 +161,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref || github.ref_name }}
-          # Full history: the auto-bump step below compares package.json's
-          # version at the fork point (merge-base with origin/main).
+          # Full history so the auto-bump step can compute the fork point
+          # (merge-base with origin/main) the same way version-guard does.
           fetch-depth: 0
 
       - name: Abort if the branch moved since the rebuild
@@ -196,22 +196,24 @@ jobs:
           path: build/
 
       - name: Auto-bump patch version for shipped-byte change
-        # version-guard now treats build/** as shipped bytes, so every
-        # bundle-changing Dependabot PR needs a version bump — without this
-        # auto-bump they would all fail the guard (and an un-bumped merge
-        # would silently never publish). Deliberately NO pnpm and NO install
-        # here: dependency lifecycle code must never run in the write-token
-        # job (token-split invariant) — plain `node -e` edits plus the
-        # repo-owned, dependency-free sync script only. The changes ride the
-        # existing "[dependabot skip]" commit below.
+        # version-guard now treats build/** as shipped bytes; without this
+        # auto-bump, every bundle-changing Dependabot PR would fail that
+        # required check (the rebuilt bundle changes what users receive, but
+        # the bot never bumps package.json). Token-split invariant: NO pnpm
+        # and NO install in this job — dependency lifecycle code must never
+        # run with the write token — so the edits below are plain `node -e`
+        # plus the repo-owned, dependency-free sync script.
         if: needs.rebuild.outputs.changed == 'true'
         run: |
+          set -euo pipefail
+          # Same fork-point semantics as version-guard: compare package.json's
+          # version field between the merge-base with origin/main and HEAD.
           git fetch --no-tags --quiet origin +refs/heads/main:refs/remotes/origin/main
-          BASE_SHA="$(git merge-base origin/main HEAD)"
-          basev="$(git show "${BASE_SHA}:package.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).version))')"
-          headv="$(node -p "require('./package.json').version")"
-          if [ "$basev" != "$headv" ]; then
-            echo "Version already bumped on this branch (${basev} -> ${headv}) — skipping auto-bump."
+          BASE="$(git merge-base origin/main HEAD)"
+          OLDV="$(git show "${BASE}:package.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).version))')"
+          NEWV="$(node -p "require('./package.json').version")"
+          if [ "$OLDV" != "$NEWV" ]; then
+            echo "Version already bumped vs fork point (${OLDV} -> ${NEWV}) — skipping auto-bump."
             exit 0
           fi
           node -e '
@@ -224,20 +226,19 @@ jobs:
             console.log("Auto-bumped version to " + pkg.version);
           '
           node scripts/sync-plugin-version.mjs
-          node -e '
+          NEWV="$(node -p "require('./package.json').version")" node -e '
             const fs = require("fs");
-            const v = require("./package.json").version;
+            const v = process.env.NEWV;
             const date = new Date().toISOString().slice(0, 10);
-            const entry = "## [" + v + "] - " + date + "\n\n### Changed\n\n- Dependency bump via Dependabot; committed bundle rebuilt. (automated)\n";
-            let c = fs.readFileSync("CHANGELOG.md", "utf8");
-            const m = c.match(/^## \[Unreleased\].*$/m);
-            if (m) {
-              const i = c.indexOf(m[0]) + m[0].length;
-              c = c.slice(0, i) + "\n\n" + entry + c.slice(i);
-            } else {
-              c = entry + "\n" + c;
-            }
-            fs.writeFileSync("CHANGELOG.md", c);
+            const entry = "## [" + v + "] - " + date + "\n### Changed\n- Dependency bump via Dependabot; committed bundle rebuilt. (automated)\n";
+            const cl = fs.readFileSync("CHANGELOG.md", "utf8");
+            const marker = "## [Unreleased]";
+            const i = cl.indexOf(marker);
+            if (i === -1) { console.error("no [Unreleased] section in CHANGELOG.md"); process.exit(1); }
+            const at = i + marker.length;
+            const rest = cl.slice(at).replace(/^\n*/, "");
+            fs.writeFileSync("CHANGELOG.md", cl.slice(0, at) + "\n\n" + entry + "\n" + rest);
+            console.log("Prepended CHANGELOG entry for " + v);
           '
           git add package.json CHANGELOG.md build .claude-plugin .agents codex .hermes-plugin .antigravity-plugin 2>/dev/null || true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,16 @@
+# ┌─────────────────────────── RENAME HAZARD ───────────────────────────┐
+# │ Three names in this pipeline are LOAD-BEARING COUPLINGS:            │
+# │  1. This FILE's name (publish.yml) is the npm Trusted Publisher     │
+# │     key — rename it and OIDC publishing breaks (photos hit this:    │
+# │     auto-release.yml had to be renamed to match).                   │
+# │  2. `workflows: [CI]` below matches ci.yml's `name:` — retitle CI   │
+# │     and this workflow never fires again (the daily schedule below   │
+# │     is the safety net that turns that silent break into a loud one).│
+# │  3. ci.yml's `test` job + matrix [22, 24] produce the required      │
+# │     branch-protection contexts `test (22)` / `test (24)` — rename   │
+# │     the job or matrix and merges block on phantom checks.           │
+# └─────────────────────────────────────────────────────────────────────┘
 name: Publish to npm
-
-# Publishes to npm when package.json's version differs from what's on npm —
-# either on a GitHub Release, or when CI succeeds on a push to main (the manual
-# `chore(release): vX.Y.Z` commit). Manual-bump model, matching the other Apple
-# MCP servers: the version is bumped in the release commit, so main's HEAD is
-# always a normal, CI'd commit (no bot-pushed version commit that GitHub won't
-# run checks on). Publishing uses OIDC trusted publishing — no NPM_TOKEN.
 
 on:
   release:
@@ -14,47 +19,80 @@ on:
     workflows: [CI]
     types: [completed]
     branches: [main]
+  # Manual retry for a stranded publish (e.g. CI flake recovered by
+  # re-dispatching CI, whose green run a workflow_run trigger would
+  # otherwise accept only for `push` events).
+  workflow_dispatch:
+  # Daily watchdog: retries any pending publish (version on main absent from
+  # npm) and self-heals a missed GitHub Release. Converts every silent
+  # never-publish variant — severed trigger coupling, race, transient npm or
+  # gh failure — into automatic recovery within 24h, or a RED run (email)
+  # when recovery fails. Runs read-only when nothing is pending.
+  schedule:
+    - cron: "17 9 * * *"
+
+# Each release can land multiple pushes on main in quick succession, so
+# multiple CI runs complete and each triggers a publish. Without
+# serialization they race: both read the pre-publish version, both attempt
+# publish, and the loser fails with a 403 "cannot publish over existing
+# version" (noisy failure emails). A concurrency group serializes them; the
+# later run then sees the version already published and skips cleanly.
+concurrency:
+  group: publish-to-npm
+  cancel-in-progress: false
 
 jobs:
   publish:
-    if: >
-      github.event_name == 'release' ||
-      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push')
     runs-on: macos-latest
+    if: >
+      (github.event_name == 'release') ||
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'schedule') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
+        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch'))
     permissions:
       id-token: write
       contents: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Checkout repository (the CI-validated commit, not a moving ref)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Release path: the release's tag/commit. Auto path: main (the commit
-          # CI just validated).
-          ref: ${{ github.event_name == 'workflow_run' && 'main' || github.ref }}
-          fetch-depth: 2
+          # For workflow_run, check out exactly the commit CI validated —
+          # otherwise a push landing between CI completion and this checkout
+          # publishes bytes (and provenance, and a Release tag) that no CI
+          # run ever saw. Other events check out their natural ref
+          # (main for schedule/dispatch, the tag for release).
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
-      - name: Check if version is already published
+      - name: Check if this exact version is already published
         id: check
+        # Exact-version existence (`npm view pkg@version`), NOT latest-equality:
+        # immune to the registry's `latest` CDN lag, and a manual Release
+        # created for an old version is a clean no-op instead of a re-publish
+        # attempt.
         run: |
+          PKG=$(node -p "require('./package.json').name")
           LOCAL_VERSION=$(node -p "require('./package.json').version")
-          PUBLISHED_VERSION=$(npm view apple-photos-mcp version 2>/dev/null || echo "0.0.0")
-          echo "Local: $LOCAL_VERSION  Published: $PUBLISHED_VERSION"
+          EXISTS=$(npm view "${PKG}@${LOCAL_VERSION}" version 2>/dev/null || echo "")
+          echo "pkg=$PKG" >> "$GITHUB_OUTPUT"
           echo "local=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
-          if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+          if [ -n "$EXISTS" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "${PKG}@${LOCAL_VERSION} is already on npm — nothing to publish."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "${PKG}@${LOCAL_VERSION} is not on npm — publishing."
           fi
 
       - name: Install dependencies
@@ -75,15 +113,34 @@ jobs:
 
       - name: Publish to npm (pnpm + OIDC trusted publishing)
         if: steps.check.outputs.skip == 'false'
-        # Phase 2 of the pnpm migration: release via `pnpm publish`. OIDC trusted
-        # publishing — no token. Requires id-token: write (above) and a Trusted
-        # Publisher configured for this package on npmjs.com (GitHub Actions →
-        # sweetrb/apple-photos-mcp, publish.yml). `--no-git-checks` skips pnpm's
-        # clean-tree/branch guard (CI checks out a detached ref).
-        run: pnpm publish --provenance --no-git-checks
+        # `pnpm publish` does the OIDC exchange + provenance (no token).
+        # `--no-git-checks` skips pnpm's clean-tree/branch guard, which CI
+        # does not satisfy.
+        #
+        # Tolerate the publish race: the concurrency group serializes runs,
+        # but npm's registry read lags the write, so a later run's existence
+        # check can miss the version a concurrent run just pushed, attempt to
+        # publish, and get a 403. Re-check and treat that case as success.
+        run: |
+          if pnpm publish --provenance --no-git-checks; then
+            echo "Published."
+          else
+            PKG="${{ steps.check.outputs.pkg }}"
+            LOCAL="${{ steps.check.outputs.local }}"
+            NOW_EXISTS=$(npm view "${PKG}@${LOCAL}" version 2>/dev/null || echo "")
+            if [ -n "$NOW_EXISTS" ]; then
+              echo "${PKG}@${LOCAL} is already on npm (published by a concurrent run); treating as success."
+            else
+              echo "::error::pnpm publish failed and ${PKG}@${LOCAL} is not on npm."
+              exit 1
+            fi
+          fi
 
-      - name: Create GitHub Release (keep Releases in sync with npm)
-        if: steps.check.outputs.skip == 'false'
+      - name: Sync GitHub Release (self-healing — runs on every trigger)
+        # Deliberately NOT gated on the skip flag: idempotent via
+        # `gh release view`, so a Release missed by a transient failure in an
+        # earlier run is healed by ANY later run, including the daily
+        # schedule.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -94,7 +151,7 @@ jobs:
             NOTES=$(awk -v v="## [$VERSION]" 'index($0,v)==1{p=1;next} p&&/^## \[/{exit} p' CHANGELOG.md)
             [ -z "$NOTES" ] && NOTES="Published to npm as v$VERSION."
             gh release create "v$VERSION" --target "$(git rev-parse HEAD)" --title "v$VERSION" --notes "$NOTES" \
-              || echo "::warning::Failed to create GitHub Release v$VERSION (npm publish still succeeded)"
+              || echo "::warning::Failed to create GitHub Release v$VERSION (will self-heal on the next run)"
           fi
 
       - name: Skip publish (version already published)

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write # publish results to the OpenSSF API (badge)
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -33,13 +33,13 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -1,15 +1,21 @@
 name: version-guard
 
-# Fail any PR to main that changes SHIPPED CODE without bumping package.json's
-# version. Shipped code = src/** (non-test), requirements.txt, and the RUNTIME
-# `dependencies` map in package.json — runtime deps are inlined into the
-# committed esbuild bundle, so bumping one changes shipped bytes too (rule
-# added 2026-07-15 alongside dependabot-rebuild.yml; previously a merged
-# runtime-dep bump silently never reached npm). Docs-only, test-only, dev-dep
-# and github-actions bumps stay exempt. Rationale: publish.yml only runs
-# `pnpm publish` when the version differs from npm, so an un-bumped code
-# change would silently never release. This makes the bump mandatory. The
-# guard file itself lives in .github/ (doesn't ship), so it needs no bump.
+# Fail any PR to main that changes SHIPPED BYTES without bumping package.json's
+# version. Shipped bytes = the committed esbuild bundle under build/** (it IS
+# what npm and marketplace users run), plus src/** (non-test) and
+# requirements.txt as first-cause detectors with better error messages, plus
+# the RUNTIME `dependencies` map in package.json. build/** was added
+# 2026-07-20: it subsumes every cause that changes what users receive — direct
+# deps, lockfile-only transitive bumps, and esbuild codegen changes — none of
+# which the src/deps detectors could see (a lockfile-only runtime-dep bump
+# merged un-bumped on 2026-07-15 and sat unshipped for two days).
+# Docs-only, test-only, and github-actions changes stay exempt; byte-neutral
+# devDependency bumps stay exempt because they leave build/ untouched.
+# Rationale: publish.yml only publishes when the version is absent from npm,
+# so an un-bumped shipped-byte change silently never releases. This guard
+# makes the bump mandatory; dependabot-rebuild.yml auto-bumps bot PRs whose
+# rebuilt bundle changed, so Dependabot automation keeps flowing.
+# The guard file itself lives in .github/ (doesn't ship), so it needs no bump.
 
 on:
   pull_request:
@@ -27,11 +33,11 @@ jobs:
   require-version-bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - name: Require a version bump when shipped code changes
+      - name: Require a version bump when shipped bytes change
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -51,15 +57,17 @@ jobs:
           changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
           echo "Changed files:"; printf '%s\n' "$changed" | sed 's/^/  /'
 
-          # Shipped-code paths: TS/JS sources and python sidecars under src/ (minus
-          # tests/mocks), plus the python dependency manifest. build/ is generated.
+          # Shipped bytes: the committed bundle itself (build/**), plus source
+          # and the python dependency manifest (minus tests/mocks) as
+          # first-cause detectors.
           code="$(printf '%s\n' "$changed" \
-            | grep -E '^(src/.*|requirements\.txt)$' \
+            | grep -E '^(src/.*|requirements\.txt|build/.*)$' \
             | grep -vE '(\.test\.ts$|\.spec\.ts$|/__tests__/|/__mocks__/)' || true)"
 
           # Runtime deps are shipped code too: they are inlined into the
           # committed bundle. Compare only the `dependencies` map —
-          # devDependencies stay exempt so dev-dep automerge is unaffected.
+          # devDependencies stay exempt so dev-dep automerge is unaffected
+          # (a devDep bump that changes the bundle is caught by build/**).
           deps_changed=""
           if printf '%s\n' "$changed" | grep -qx 'package.json'; then
             old_deps="$(git show "${BASE_SHA}:package.json" | jq -cS '.dependencies // {}')"
@@ -72,34 +80,50 @@ jobs:
             fi
           fi
 
-          if [ -z "$code" ] && [ -z "$deps_changed" ]; then
-            echo "::notice::No shipped-code changes — version bump not required."
-            exit 0
-          fi
-          if [ -n "$code" ]; then
-            echo "Shipped-code changes detected:"; printf '%s\n' "$code" | sed 's/^/  /'
-          fi
-
           oldv="$(git show "${BASE_SHA}:package.json" \
             | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>console.log(JSON.parse(s).version))')"
           newv="$(node -e 'console.log(require("./package.json").version)')"
           echo "package.json version: base=${oldv}  head=${newv}"
 
+          if [ "$oldv" != "$newv" ]; then
+            # Bump present: require it to be an increase (typo'd downgrades)…
+            OLDV="$oldv" NEWV="$newv" node -e '
+              const a = process.env.OLDV.split(".").map(Number);
+              const b = process.env.NEWV.split(".").map(Number);
+              const cmp = (b[0]-a[0]) || (b[1]-a[1]) || (b[2]-a[2]);
+              if (cmp > 0) { console.log("Version bumped " + process.env.OLDV + " -> " + process.env.NEWV + "."); process.exit(0); }
+              console.error("::error::package.json version went " + process.env.OLDV + " -> " + process.env.NEWV + " (not an increase). Bump it forward.");
+              process.exit(1);
+            '
+            # …and require it to be UNPUBLISHED. Two concurrently-open PRs can
+            # each bump to the same next patch; without this, the second merge
+            # is a version collision publish.yml silently skips. Registry
+            # errors fail open (a registry outage must not block merges).
+            PKG="$(node -p "require('./package.json').name")"
+            set +e
+            existing="$(npm view "${PKG}@${newv}" version 2>/dev/null)"
+            set -e
+            if [ -n "$existing" ]; then
+              echo "::error::${PKG}@${newv} is already published on npm — this bump collides with an existing release (another PR likely claimed it first). Rebase on main and bump again:  pnpm version patch --no-git-tag-version"
+              exit 1
+            fi
+            echo "${PKG}@${newv} is unclaimed on npm."
+          fi
+
+          if [ -z "$code" ] && [ -z "$deps_changed" ]; then
+            echo "::notice::No shipped-byte changes — version bump not required."
+            exit 0
+          fi
+          if [ -n "$code" ]; then
+            echo "Shipped-byte changes detected:"; printf '%s\n' "$code" | sed 's/^/  /'
+          fi
+
           if [ "$oldv" = "$newv" ]; then
             if [ -n "$deps_changed" ]; then
               echo "::error::Runtime dependencies changed (the shipped bundle changes) but package.json version is unchanged (${oldv}). Bump at least a patch + add a CHANGELOG entry so publish.yml actually ships the dependency update:  pnpm version patch --no-git-tag-version"
             else
-              echo "::error::Shipped code changed but package.json version is unchanged (${oldv}). Bump it at least a patch:  pnpm version patch --no-git-tag-version  (and add a CHANGELOG entry)."
+              echo "::error::Shipped bytes changed (src/, requirements.txt, or the committed build/ bundle) but package.json version is unchanged (${oldv}). Bump it at least a patch:  pnpm version patch --no-git-tag-version  (and add a CHANGELOG entry)."
             fi
             exit 1
           fi
-
-          # Guard against a typo'd downgrade — require the new version to be greater.
-          OLDV="$oldv" NEWV="$newv" node -e '
-            const a = process.env.OLDV.split(".").map(Number);
-            const b = process.env.NEWV.split(".").map(Number);
-            const cmp = (b[0]-a[0]) || (b[1]-a[1]) || (b[2]-a[2]);
-            if (cmp > 0) { console.log("Version bumped " + process.env.OLDV + " -> " + process.env.NEWV + "."); process.exit(0); }
-            console.error("::error::package.json version went " + process.env.OLDV + " -> " + process.env.NEWV + " (not an increase). Bump it forward.");
-            process.exit(1);
-          '
+          echo "Shipped bytes changed and version is bumped — OK."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+pnpm exec lint-staged
+# Rebuild the committed bundle when shipped inputs are staged, so a stale
+# build/ can never be committed alongside source (CI's verify step would
+# fail the PR otherwise).
+if git diff --cached --name-only | grep -qE '^(src/|package\.json$|pnpm-lock\.yaml$)'; then
+  pnpm run build
+  git add build
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.1.2] - 2026-07-20
+
+### Changed
+- CI/release hardening: `version-guard` now treats the committed `build/` bundle as shipped bytes (closing the lockfile-only and devDep silent-never-publish vectors) with an npm version-collision check; `publish.yml` gained a daily self-healing watchdog, manual dispatch, exact-version skip, CI-validated-commit checkout, and GitHub-Release self-heal; Dependabot bundle rebuilds now auto-bump a patch version; CI boots the committed bundle standalone on Node 20 every run; the bundle is now built with `--target=node20`, making the `engines.node >= 20` claim enforced at build time.
+- `requirements.txt` is now exact-pinned and under Dependabot pip management; CodeQL scans the Python sidecar.
+
 ### Documentation
 - **`docs/FULL-DISK-ACCESS.md`** — adds a "still failing after granting every host app?" section (#37 follow-up): on at least one confirmed setup, TCC attributed the FDA check directly to the `node` binary itself, not to any wrapper app — responsibility never climbed past `node` to see those grants. Documents the definitive diagnostic (`log stream --predicate 'subsystem == "com.apple.TCC"'`, reading the `Resp:` process from the denial) and the fix (grant FDA to the exact `node` path the log names), plus the ad-hoc-vs-Developer-ID-signature note on why the grant may or may not survive a Node upgrade.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,10 @@ Thank you for your interest in contributing! This document provides guidelines f
 
 2. **Install dependencies**
    ```bash
-   pnpm install
+   corepack enable && pnpm install --frozen-lockfile
    ```
 
-   This repo pins pnpm via `packageManager` in `package.json` — `corepack enable` provides it. Development needs Node >= 22.13 (CI tests on Node 22 and 24); the published server itself runs on Node >= 20.
+   This repo pins pnpm via `packageManager` in `package.json` — `corepack enable` provides it. Development needs Node >= 22.13 (CI tests on Node 22 and 24); the published server itself runs on Node >= 20. npm and yarn are blocked by a `preinstall` guard in git checkouts: they resolve dependencies off-lockfile, so the committed bundle would mismatch CI.
 
 3. **Set up the Python sidecar** (creates a project-local venv with `osxphotos`)
    ```bash
@@ -62,9 +62,17 @@ All new features should include tests. We use Vitest.
 1. Create a feature branch (`git checkout -b feature/your-feature-name`).
 2. Make your changes — follow the existing style, add JSDoc, add tests.
 3. Run all checks: `pnpm run lint && pnpm run typecheck && pnpm run format:check && pnpm test && pnpm run build`.
-4. If you changed shipped code (`src/**` excluding tests, the runtime `dependencies` in `package.json`, or `requirements.txt`), bump the version at least a patch (`pnpm version patch --no-git-tag-version`) and add a CHANGELOG.md entry in the same PR — the `require-version-bump` CI check fails the PR otherwise (docs-only and test-only PRs are exempt). Rebuild and commit the bundled `build/index.js` (`pnpm run build`); CI verifies it matches the source.
+4. Satisfy everything in "What CI requires of your PR" below.
 5. Commit with clear messages referencing any related issues.
 6. Push and open a PR describing what it does and linking related issues.
+
+## What CI requires of your PR
+
+- **A version bump + CHANGELOG entry for shipped code.** If your PR changes shipped bytes — `src/**` (excluding tests), the runtime `dependencies` in `package.json`, `requirements.txt`, or the committed `build/` bundle — bump the version at least a patch (`pnpm version patch --no-git-tag-version`) and add a CHANGELOG.md entry in the same PR. The `require-version-bump` check fails the PR otherwise (docs-only and test-only PRs are exempt), and also rejects a bump to a version that is already published on npm.
+- **A rebuilt, committed `build/index.js`.** Run `pnpm run build` and commit the bundle alongside your source changes — CI rebuilds and fails on any byte difference, and separately boots the committed bundle standalone on Node 20.
+- **Prettier-clean formatting** (`pnpm run format:check`) and a clean ESLint run (`pnpm run lint`).
+- **Green tests with coverage above the enforced thresholds** (`pnpm run test:coverage`), plus the integration suite (`pnpm run test:integration`).
+- **Plugin manifests in sync** — `node scripts/sync-plugin-version.mjs --check` must pass (`pnpm version` keeps them synced automatically).
 
 ## Adding New Tools
 

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos-mcp",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Photos - query, search, export, and inspect the macOS Photos library via Claude and other AI assistants, plus opt-in album/metadata write tools (read-only by default)",
   "type": "module",
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "setup": "bash scripts/setup.sh",
-    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=esm --outfile=build/index.js --banner:js=\"import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);\"",
+    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=build/index.js --banner:js=\"import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);\"",
     "start": "node build/index.js",
     "dev": "tsc --watch",
     "lint": "eslint src",
@@ -35,6 +35,7 @@
     "test:all": "vitest run && vitest run --config vitest.integration.config.ts",
     "version": "node scripts/sync-plugin-version.mjs && git add .claude-plugin .agents/plugins codex .hermes-plugin .antigravity-plugin",
     "prepublishOnly": "pnpm run lint && pnpm test && pnpm run build",
+    "preinstall": "node -e \"const fs=require('fs');const ua=process.env.npm_config_user_agent||'';if(fs.existsSync('.git')&&!ua.startsWith('pnpm')){console.error('\\nThis repo uses pnpm. npm/yarn resolve dependencies off-lockfile and the committed bundle will mismatch CI.\\n\\n  corepack enable && pnpm install --frozen-lockfile\\n');process.exit(1)}\"",
     "prepare": "husky; pnpm run build"
   },
   "volta": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-osxphotos>=0.69.0,<0.76
+# Exact-pinned (2026-07-20) so the sidecar environment is reproducible and
+# Dependabot's pip ecosystem can propose auditable bumps.
+osxphotos==0.75.9
 # Direct dependency of the opt-in write tools (also an osxphotos transitive
 # dep). Pinned because photos_reader.py uses its script_loader.run_script for
-# bulk album-id calls — keep the floor/ceiling in step when bumping.
-photoscript>=0.5.3,<0.6
+# bulk album-id calls — keep the two pins in step when bumping.
+photoscript==0.5.3

--- a/scripts/sync-plugin-version.mjs
+++ b/scripts/sync-plugin-version.mjs
@@ -1,9 +1,14 @@
+// Sync every plugin-manifest version to package.json's version.
+// With --check: write nothing — exit 0 silently when every manifest already
+// matches, exit 1 listing the mismatched files otherwise (used by CI).
 import fs from "node:fs";
 import path from "node:path";
 
+const check = process.argv.includes("--check");
 const root = process.cwd();
 const packageJson = readJson("package.json");
 const version = packageJson.version;
+const mismatches = [];
 
 updateJson(".claude-plugin/plugin.json", (data) => {
   data.version = version;
@@ -42,13 +47,30 @@ updateJson(".antigravity-plugin/marketplace.json", (data) => {
   }
 });
 
+if (check && mismatches.length > 0) {
+  console.error(`Plugin manifests out of sync with package.json (${version}):`);
+  for (const file of mismatches) {
+    console.error(`  ${file}`);
+  }
+  console.error("Run: node scripts/sync-plugin-version.mjs");
+  process.exit(1);
+}
+
 function readJson(relativePath) {
   return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8"));
 }
 
 function updateJson(relativePath, update) {
   const fullPath = path.join(root, relativePath);
-  const data = readJson(relativePath);
+  const before = fs.readFileSync(fullPath, "utf8");
+  const data = JSON.parse(before);
   update(data);
-  fs.writeFileSync(fullPath, `${JSON.stringify(data, null, 2)}\n`);
+  const after = `${JSON.stringify(data, null, 2)}\n`;
+  if (check) {
+    if (after !== before) {
+      mismatches.push(relativePath);
+    }
+    return;
+  }
+  fs.writeFileSync(fullPath, after);
 }


### PR DESCRIPTION
CI/release hardening per the 2026-07-20 audit — apple-photos-mcp instance of the four-repo canonical change set. Bumps `2.1.1 -> 2.1.2`.

## What changed

### Workflows
- **`version-guard.yml`** (canonical replacement): `build/**` now counts as **shipped bytes** — the guard catches lockfile-only transitive runtime-dep bumps, devDep bumps that change the bundle, and esbuild codegen changes, none of which the old src/deps detectors could see. Also new: the bumped version must be an *increase* and must be **unpublished on npm** (two open PRs claiming the same patch can no longer produce a silent version-collision skip; registry errors fail open).
- **`publish.yml`** (canonical replacement): daily self-healing watchdog schedule (converts every silent never-publish variant into recovery within 24h or a loud red run), `workflow_dispatch` manual retry, exact-version existence skip (immune to `latest` CDN lag), `workflow_run` publishes **exactly the commit CI validated**, concurrency serialization + publish-race tolerance, and an idempotent GitHub-Release self-heal that runs on every trigger.
- **`dependabot-rebuild.yml`**: the write job now **auto-bumps a patch version** when the rebuilt bundle differs and the PR hasn't bumped already (fork-point comparison) — required because version-guard now fails bundle-changing PRs without a bump. Token-split invariant preserved: no pnpm/no install in the write job, only `node -e` edits + the dependency-free repo-owned sync script; the changes ride the existing `[dependabot skip]` commit; the ci.yml/version-guard re-dispatch is unchanged. Push-job checkout deepened to `fetch-depth: 0` for the merge-base computation.
- **`ci.yml`**: new **`bundle-boots (standalone, Node 20)`** job — boots the committed bundle with no `node_modules` on the oldest supported Node and validates the MCP `initialize` handshake (perl-alarm timeout; macOS runners have no `timeout` binary); the verify step gains an **untracked-emissions guard** (a build emitting files the `.gitignore` re-includes don't cover fails loudly); new **`Verify plugin manifests match package.json version`** step; **codecov upload** step (matching mail's); RENAME HAZARD header documenting the `name: CI` / `test (22)`/`test (24)` couplings.
- **`codeql.yml`**: language matrix is now `[javascript-typescript, python]` — CodeQL scans the osxphotos sidecar (`src/utils/photos_reader.py`).
- **`scorecard.yml` / `dependabot-automerge.yml`**: pin bumps only.
- **Action pins** (all workflows): checkout v7.0.1, setup-node v7.0.0, setup-python v7.0.0, upload-artifact v7.0.1, codecov v7.0.0, codeql-action v4.37.1, fetch-metadata v3.1.0 — all SHA-pinned. `pnpm/action-setup` deliberately left at v4.4.0.

### Repo
- **`.github/dependabot.yml`**: github-actions majors no longer ignored (Dependabot maintains the new pins); new **pip ecosystem** block (weekly, 7-day cooldown, grouped, majors ignored).
- **`scripts/sync-plugin-version.mjs`**: `--check` mode — compares every manifest it would write, writes nothing, exit 1 listing mismatches (wired into CI).
- **`package.json`**: esbuild **`--target=node20`** (the `engines.node >= 20` claim is now enforced at build time); **preinstall guard** — npm/yarn installs in a git checkout fail loudly with the corepack/pnpm one-liner (registry tarballs contain no `.git`, so end-user installs are unaffected); version 2.1.2.
- **`requirements.txt`**: exact-pinned to the venv-installed versions (`osxphotos==0.75.9`, `photoscript==0.5.3`) so the pip ecosystem can propose auditable bumps.
- **`.husky/pre-commit`**: created (photos had none — the existing `lint-staged` config in package.json was dead; this revives it) — canonical content: lint-staged + auto-rebuild/stage of `build/` when shipped inputs are staged.
- **`CONTRIBUTING.md`**: frozen-lockfile install command, npm/yarn-guard note, new "What CI requires of your PR" section.
- **`CHANGELOG.md`**: 2.1.2 entry (2026-07-20).

## Notes / deviations
- **vitest 4 deferred**: `pnpm add -D vitest@^4 @vitest/coverage-v8@^4` ran green on tests but **fails the enforced coverage thresholds** under vitest 4's v8 remapping — `src/tools/**` functions 85.71% < 90%, branches 73.61% < 80%. Reverted; staying on ^3.2.6.
- **`--target=node20` produced a byte-identical bundle** for this repo (no syntax needed downleveling), so `build/index.js` is unchanged in this PR; the patch bump still applies (requirements.txt + package.json are shipped-code changes).
- **requirements.txt**: both listed packages were present in the shared checkout's venv — both exact-pinned, no kept ranges.
- The pre-existing `[Unreleased]` CHANGELOG item (FULL-DISK-ACCESS.md docs) was folded into 2.1.2 — it ships with this release.

## Local verification (all green)
- `pnpm run lint` + `pnpm run typecheck` + `pnpm run format:check` + `pnpm test` (288/288)
- `pnpm run test:integration` against the real Photos library (40 passed, 15 skipped = gated/live-writes as designed)
- Bundle rebuilt deterministically in a clean-room worktree (frozen install); `git diff --quiet -- build/` after final commit
- YAML-parse of all 7 workflow files + dependabot.yml
- Standalone boot smoke exactly like the new CI job (mktemp, no node_modules): `apple-photos-mcp v2.1.2 running on stdio`
- npm-guard both directions: `npm install --ignore-scripts=false` in a git-marked layout fails loudly with the guard message; `pnpm install --frozen-lockfile` passes
- `node scripts/sync-plugin-version.mjs --check` passes; all 6 manifest versions == 2.1.2
