### PR TITLE
ci: skip npm publishing in forks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,11 +45,12 @@ jobs:
   publish:
     runs-on: macos-latest
     if: >
-      (github.event_name == 'release') ||
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'schedule') ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
-        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch'))
+      github.repository_owner == 'sweetrb' &&
+      ((github.event_name == 'release') ||
+       (github.event_name == 'workflow_dispatch') ||
+       (github.event_name == 'schedule') ||
+       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
+         (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch')))
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
Gates the `publish` job on `github.repository_owner == 'sweetrb'` so a fork that syncs this workflow does not attempt to publish (no OIDC trusted-publisher → errors / red runs in the fork).

Fleet-wide companion to sweetrb/apple-notes-mcp#102 (@oliverames), applied byte-identically across all four repos so `./conformance-check.sh` continues to pass. Workflow-only, no version bump.