### PR TITLE
test: fix flaky serve-mode progress assertion that blocked the 2.1.4 publish

### DIFF
--- a/test/persistent-sidecar.test.ts
+++ b/test/persistent-sidecar.test.ts
@@ -229,8 +229,12 @@ describe("persistent sidecar (real server over stdio, synthetic serve sidecar)",
       expect(structured?.exportedCount).toBe(3);
       expect(structured?.skippedCount).toBe(0);
 
-      // One notification per photo plus the final done=total line.
-      expect(progress.length).toBe(4);
+      // One notification per photo plus the final done=total line. callTool
+      // resolves on the result message, but the final progress notification is a
+      // separate async message that can still be in flight then — asserting the
+      // count synchronously here raced it (seen: `expected 3 to be 4`). Wait for
+      // all four to land first.
+      await expect.poll(() => progress.length, { timeout: 10_000 }).toBe(4);
       expect(progress[0]).toMatchObject({ progress: 0, total: 3 });
       expect(progress[0].message).toContain("IMG_0000.jpg");
       expect(progress[0].message).toContain("(1/3)");


### PR DESCRIPTION
The persistent-sidecar integration test `forwards serve-mode export progress as MCP progress notifications` asserted `progress.length === 4` synchronously right after `client.callTool` resolved.

`callTool` resolves on the **result** message, but the final `done=total` progress notification is a **separate async message** that can still be in flight at that moment — so the count was intermittently 3. This is exactly what failed the `integration` job on the #47 merge (`expected 3 to be 4`), which made CI red and caused `publish.yml` to skip, so **2.1.4 never published** until I re-ran the job.

Fix: wait for all four notifications to land (`await expect.poll(() => progress.length, { timeout: 10_000 }).toBe(4)`) before asserting, instead of racing the count. The synthetic sidecar already emits four deterministically (3 per-photo + 1 done-line), so this only closes the client-side receive race.

Verified: **15/15** green in a stress loop (was intermittently failing before). Test-only change — no shipped bytes, so version-bump/CHANGELOG exempt.