### PR TITLE
chore(deps): bump github/codeql-action 4.37.1 -> 4.37.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
       - name: Analyze
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -40,6 +40,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Restores four-repo workflow conformance.

`apple-mail-mcp` (#114) and `apple-numbers-mcp` (#41) both took the `github/codeql-action` 4.37.1 → 4.37.3 bump from the weekly Dependabot github-actions group this morning. No equivalent PR was opened for notes or photos, which left `codeql.yml` and `scorecard.yml` split 2-2 across the family and `conformance-check.sh` failing with 4 DRIFT findings.

All four repos have byte-identical `dependabot.yml` github-actions blocks (weekly, 7-day cooldown, grouped `*`), so this is a missed run rather than a config difference — bumping by hand rather than waiting on the next weekly slot.

Pin verified against the upstream tag before use:

```
$ gh api repos/github/codeql-action/commits/v4.37.3 --jq .sha
e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
```

No version bump or CHANGELOG entry: github-actions-only changes are exempt from `version-guard`, and nothing shipped to npm changes. Matches how #114 and #41 landed.