### PR TITLE
test: de-flake the persistent-sidecar export-progress assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - **`pnpm version` no longer breaks with the `.hermes-plugin/` removal.** The `version` lifecycle script listed `.hermes-plugin` in its `git add`; `git add` exits 128 on a pathspec that matches nothing, which would have broken the documented release step (`pnpm version <patch|minor|major> --no-git-tag-version`) for every subsequent release. The stale path is dropped from the `git add` list.
+- **Flaky `persistent-sidecar` integration test.** The export-progress assertion waits for the final `done=total` notification, which arrives as a separate async message after `callTool` already resolved. Its 10s poll budget still lost the race on a loaded CI runner (`expected 3 to be 4`, seen blocking #52), so unrelated PRs could fail `integration` for no reason. Raised to 30s — this is an "has it arrived yet" wait rather than a latency assertion, and the enclosing test's own 60s budget is still the real bound, so the assertion is not weakened.
 
 ## [2.1.4] - 2026-07-22
 

--- a/test/persistent-sidecar.test.ts
+++ b/test/persistent-sidecar.test.ts
@@ -234,7 +234,13 @@ describe("persistent sidecar (real server over stdio, synthetic serve sidecar)",
       // separate async message that can still be in flight then — asserting the
       // count synchronously here raced it (seen: `expected 3 to be 4`). Wait for
       // all four to land first.
-      await expect.poll(() => progress.length, { timeout: 10_000 }).toBe(4);
+      //
+      // The poll ceiling is deliberately generous: a 10s budget still flaked on
+      // a loaded CI runner with the same `expected 3 to be 4` (blocking #52).
+      // This is a "has it arrived yet" wait, not a latency assertion — nothing
+      // is measured here, and the enclosing test's own 60s budget remains the
+      // real bound, so a longer ceiling only costs time on genuine failure.
+      await expect.poll(() => progress.length, { timeout: 30_000 }).toBe(4);
       expect(progress[0]).toMatchObject({ progress: 0, total: 3 });
       expect(progress[0].message).toContain("IMG_0000.jpg");
       expect(progress[0].message).toContain("(1/3)");


### PR DESCRIPTION
`test/persistent-sidecar.test.ts` waits for the final `done=total` progress notification, which arrives as a **separate async message** after `callTool` has already resolved. Its 10s `expect.poll` budget still lost that race on a loaded CI runner — `expected 3 to be 4`, the exact failure the test's own comment documents having seen before — and it blocked an unrelated PR ([#52](https://github.com/sweetrb/apple-photos-mcp/pull/52)) until a manual rerun.

Raised the poll ceiling from 10s to 30s.

**This does not weaken the assertion.** It is a "has it arrived yet" wait, not a latency assertion — nothing is being measured. The test still requires exactly four notifications with the correct `progress`/`total`/`message` shape, and the enclosing test's own 60s budget remains the real bound. A genuine regression still fails; it just waits longer before doing so.

Test-only change: committed bundle byte-identical, 288 unit tests pass, no version bump owed.