### PR TITLE
docs(scripts): drop the stale .hermes-plugin note from sync-skills.mjs

### DIFF
--- a/scripts/sync-skills.mjs
+++ b/scripts/sync-skills.mjs
@@ -1,8 +1,7 @@
 // Root skills/ is the canonical copy; the per-surface duplicates
 // (codex/skills/, .antigravity-plugin/skills/) are generated from it and must
 // never be edited directly. (.agents/plugins/marketplace.json sources ./codex,
-// and .hermes-plugin carries no skill copy — syncing codex covers every other
-// surface.)
+// so syncing codex covers every other surface.)
 //
 //   node scripts/sync-skills.mjs          overwrite the copies from skills/
 //   node scripts/sync-skills.mjs --check  exit 1 on any drift (CI gate)


### PR DESCRIPTION
Last remaining reference to the removed `.hermes-plugin/` directory. The comment explained that hermes "carries no skill copy" — now that the directory is gone, it only sends a reader looking for something that no longer exists. The clause that still matters (`.agents/plugins/marketplace.json` sources `./codex`, so syncing codex covers every other surface) is kept.

Comment only — script behavior unchanged and `sync-skills.mjs --check` still passes in all four repos. `scripts/` is not in `package.json` `files[]`, so nothing ships: no version bump, and no CHANGELOG entry for a comment correction.

The file is byte-identical across all four repos (ci.yml's skill-copy verification and `conformance-check.sh` both depend on that), so this identical commit lands in each — verified matching sha256 after the edit.