### PR TITLE
ci(version-guard): require a CHANGELOG heading for every version bump

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -16,6 +16,9 @@ name: version-guard
 # makes the bump mandatory; dependabot-rebuild.yml auto-bumps bot PRs whose
 # rebuilt bundle changed, so Dependabot automation keeps flowing.
 # The guard file itself lives in .github/ (doesn't ship), so it needs no bump.
+# A bump must also be DOCUMENTED: when the version changes, CHANGELOG.md has to
+# carry a matching "## [X.Y.Z]" heading, so release notes can't be stranded
+# under "## [Unreleased]" and silently orphaned once the release ships.
 #
 # TypeScript under src/ is a FIRST-CAUSE DETECTOR, not a shipped file: it
 # reaches users only after esbuild inlines it into build/index.js. So it only
@@ -140,6 +143,22 @@ jobs:
               exit 1
             fi
             echo "${PKG}@${newv} is unclaimed on npm."
+
+            # …and require CHANGELOG.md to document it under a REAL version
+            # heading. An entry parked under "## [Unreleased]" is orphaned the
+            # moment the release ships: nothing in the release path renames
+            # that section (the `version` lifecycle script only syncs the
+            # plugin manifests), so the published version ends up undocumented
+            # while its notes sit under a heading claiming they are unreleased.
+            # apple-notes-mcp shipped 2.6.10 and 2.6.11 exactly that way before
+            # this check existed. dependabot-rebuild.yml already inserts a real
+            # heading, so bot PRs pass unchanged.
+            esc="$(printf '%s' "${newv}" | sed 's/\./\\./g')"
+            if ! grep -qE "^## \[${esc}\]" CHANGELOG.md; then
+              echo "::error::package.json bumped to ${newv} but CHANGELOG.md has no '## [${newv}]' heading. Move this release's notes out of '## [Unreleased]' and file them under '## [${newv}] - $(date -u +%Y-%m-%d)'. Keep an empty '## [Unreleased]' at the top — dependabot-rebuild.yml hard-fails without that marker."
+              exit 1
+            fi
+            echo "CHANGELOG.md documents ${newv}."
           fi
 
           if [ -z "$code" ] && [ -z "$deps_changed" ]; then


### PR DESCRIPTION
## Description

A version bump and its release notes could drift apart, silently.

Entries get written under `## [Unreleased]`, and **nothing in the release path ever renames that section** — the `version` lifecycle script only syncs the plugin manifests. So once a release ships, its notes stay filed under a heading claiming they are unreleased, and the published version is left undocumented.

`apple-notes-mcp` shipped **2.6.10 and 2.6.11** exactly that way (found and corrected in #116). The drift is invisible per-PR: every individual PR looks correct, and only the accumulated `[Unreleased]` section reveals it.

`version-guard` already runs on the one event that matters — `package.json`'s version changing in a PR — so the check belongs there. When the version changes, `CHANGELOG.md` must carry a matching `## [X.Y.Z]` heading.

## Behaviour

- **Scoped to bumps only** — docs-only, test-only and byte-neutral PRs are untouched.
- **Dependabot passes unchanged** — `dependabot-rebuild.yml` already inserts a real `## [X.Y.Z] - DATE` heading rather than writing under `[Unreleased]`.
- **The version string is regex-escaped**, so `2.6.12` cannot match a literal `2X6X12`.
- The error message tells you to keep an empty `## [Unreleased]` at the top, because `dependabot-rebuild.yml` **hard-exits** when that marker is missing.

## Verification

The matcher was exercised against the real CHANGELOGs before this landed:

| case | expected | result |
|---|---|---|
| mail 2.9.1 / numbers 1.1.10 / photos 2.1.5 (current, documented) | pass | pass |
| notes 2.6.12 after the #116 restructure | pass | pass |
| notes 2.6.11 as it stood pre-fix (the real orphaning) | **fail** | fail |
| an undocumented version (9.9.9) | **fail** | fail |
| dot-escaping: `2.6.12` vs a `## [2X6X12]` heading | **fail** | fail |

Applied **identically to all four repos** — `version-guard.yml` is in `conformance-check.sh`'s IDENTICAL set.

## Type of Change

- [x] Other: CI guard

## Checklist

- [x] `.github/` does not ship, so no version bump is owed (`require-version-bump` exempts it)