### PR TITLE
ci: bump pinned ossf/scorecard-action to v2.4.4 (conformance drift)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Security
+- **Bumped the pinned `ossf/scorecard-action` to `2d1146689b8cda280b9bc96326124645441f03bc` (v2.4.4).** Dependabot's weekly `github-actions` group PR landed this in apple-mail-mcp (#134) and apple-numbers-mcp (#56) but skipped this repo and apple-notes-mcp, so `conformance-check.sh` reported `DRIFT: .github/workflows/scorecard.yml differs`. The four servers are meant to carry a byte-identical workflow set, and a silent group-skip is the recurring way that breaks. `.github/` does not ship, so this owes no version bump.
+
 ## [2.1.7] - 2026-08-03
 
 ### Security


### PR DESCRIPTION
Restores the byte-identical workflow set across the four servers.

Dependabot's weekly `github-actions` group PR bumped `ossf/scorecard-action` to `2d1146689b8cda280b9bc96326124645441f03bc` (v2.4.4) in **apple-mail-mcp (#134)** and **apple-numbers-mcp (#56)** today, but silently skipped this repo and its sibling — the known group-skip failure mode. `./conformance-check.sh` was reporting:

```
DRIFT: .github/workflows/scorecard.yml differs: apple-notes-mcp vs apple-mail-mcp
DRIFT: .github/workflows/scorecard.yml differs: apple-photos-mcp vs apple-mail-mcp
```

The drift is exactly one line — the pinned SHA on line 29 — and nothing fails on its own when it happens, which is what makes it worth catching in the conformance sweep rather than waiting for the next group PR to maybe include the laggards.

**No version bump:** `.github/` is not shipped bytes, so `version-guard` does not require one and the CHANGELOG entry stays under `[Unreleased]` with no heading of its own.