### PR TITLE
fix(schema): advertise every tool's outputSchema as permissive (propagates apple-mail-mcp#135)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-photos-mcp",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Apple Photos integration for Claude Code via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -11,7 +11,7 @@
     {
       "name": "apple-photos",
       "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only)",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [2.1.9] - 2026-08-06
+
+### Fixed
+- **Every tool advertised an output schema that rejected undeclared keys, discarding otherwise-correct results.** The MCP **client** validates a result's `structuredContent` against the JSON Schema the server *advertised*, not against the server's own zod object — and a bare zod raw shape renders as `additionalProperties: false`. So any field a handler emits that its schema doesn't enumerate is a hard client-side `-32602 … data must NOT have additional properties`, throwing away a payload the handler computed correctly. The server never notices, because zod's own parse silently *strips* unknown keys instead of failing, which is exactly why the `registerTool`/`outputSchema` migration's "all fields optional, no `.strict()`" read as permissive: it covered optionality, not undeclared keys. All **21 tools** in this repo were advertising `additionalProperties: false`. Every tool now registers through a wrapper applying `.passthrough()`, advertising `additionalProperties: true` — the contract that migration intended. Found while fixing the same defect in the sibling apple-mail-mcp (sweetrb/apple-mail-mcp#135), where it was not latent: it broke `get-mail-stats` on every call for anyone with IMAP configured.
+
+### Added
+- **The outputSchema contract test now asserts that every tool tolerates undeclared keys.** The existing checks — every tool has an `outputSchema`, none requires a field — could not see this class, because they inspect the advertised schema and round-trip only the diagnostic tools; a tool whose payload carries an undeclared key passes CI and fails in the user's client. The suite now fails any tool advertising `additionalProperties: false`, so this cannot silently return.
+
 ## [2.1.8] - 2026-08-05
 ### Changed
 - Dependency bump via Dependabot; committed bundle rebuilt. (automated)

--- a/build/index.js
+++ b/build/index.js
@@ -23050,7 +23050,15 @@ var uuidSchema = external_exports.string().max(256).regex(
   /^[0-9A-Fa-f-]+$/,
   "must be a Photos UUID \u2014 hexadecimal segments separated by dashes (e.g. 1EB2B765-0765-43BA-A90C-0F0AE547B343)"
 );
-server.registerTool(
+function registerTool(name, config2, cb) {
+  const { outputSchema, ...rest } = config2;
+  return server.registerTool(
+    name,
+    outputSchema ? { ...rest, outputSchema: external_exports.object(outputSchema).passthrough() } : rest,
+    cb
+  );
+}
+registerTool(
   "health-check",
   {
     description: "Use when: you want a quick smoke test that osxphotos is installed and the Photos library can be opened.\nReturns: ok/fail plus the osxphotos version, library path, and total photo count. While another operation (a long query or export) is running, it responds immediately with a liveness summary instead of queueing behind it \u2014 re-run after the operation completes for the full result.\nDo not use when: you need a full setup diagnostic that pinpoints whether the failure is a missing osxphotos, an unreadable library, or denied Full Disk Access \u2014 use doctor instead.",
@@ -23067,7 +23075,7 @@ server.registerTool(
     });
   }, "health-check")
 );
-server.registerTool(
+registerTool(
   "doctor",
   {
     description: "Use when: a tool returns a permission, 'unable to open', or 'write tools are disabled' error, or you want a full setup diagnostic before querying, exporting, or writing.\nReturns: six checks \u2014 Python interpreter (path + version; warns below 3.11), osxphotos install, sidecar mode (persistent vs one-shot, plus last respawn), the write-tools gate (enabled/disabled, with the opt-in recipe and \u2014 when enabled \u2014 whether the photoscript backend and Photos.app look usable), Photos library readability, and Full Disk Access \u2014 each reported ok/warn/fail with actionable advice.\nDo not use when: you only need the lightweight is-it-working smoke test \u2014 use health-check instead.",
@@ -23088,7 +23096,7 @@ server.registerTool(
     return successResponse(formatDoctorReport(report), { ...report });
   }, "doctor")
 );
-server.registerTool(
+registerTool(
   "library-info",
   {
     description: "Use when: you want high-level stats about the whole library \u2014 total counts of photos, movies, albums, folders, keywords, and persons \u2014 or to confirm which library you're targeting before drilling in.\nReturns: the library path, Photos DB and Photos.app versions, and the six counts.\nDo not use when: you want the actual albums/keywords/persons rather than just their counts \u2014 use list-albums / list-keywords / list-persons; or you want to find specific photos \u2014 use query.",
@@ -23123,7 +23131,7 @@ Persons:   ${info.personCount}`,
     );
   }, "library-info")
 );
-server.registerTool(
+registerTool(
   "query",
   {
     description: "Use when: you need to find photos matching one or more filters \u2014 album, keyword, person, ML label, place, GPS radius (near), folder, taken-date or import-date range (addedAfter/addedInLast for 'recently imported'), year, file size, media type (screenshot, screen recording, selfie, panorama, live, portrait, time-lapse, slow-mo, burst, video), aesthetic score (minScore), OCR-detected text (detectedText), favorite/hidden flags, or title/description substrings \u2014 and get back a list of matches. This is the primary search/discovery tool; start here when you don't already have a UUID. Hidden photos are excluded unless hidden=true. Pass newestFirst=true with a limit to get the N most recent matches.\nReturns: count (the TOTAL number of matches), returned (the number of summaries in this response \u2014 capped at limit, default 500), and photo summaries (UUID, filename, date, dimensions, favorite/hidden/movie flags) \u2014 feed a UUID into get-photo/get-photos for full metadata, get-thumbnail to see it, or export to copy files.\nDo not use when: you already have UUIDs and want full metadata \u2014 use get-photo / get-photos; you want to see an image \u2014 use get-thumbnail; or you just want the catalog of album/keyword/person names \u2014 use list-albums / list-keywords / list-persons.",
@@ -23237,7 +23245,7 @@ ${lines.join("\n")}`, {
     });
   }, "query")
 );
-server.registerTool(
+registerTool(
   "get-photo",
   {
     description: "Use when: you have a single photo's UUID (typically from query) and want its complete metadata.\nReturns: dimensions and original dimensions, dates, title/description, location and place, albums, keywords, persons, labels, file paths, size, EXIF camera data (make/model, lens, ISO, aperture, shutter speed, focal length \u2014 null when Photos recorded none), Photos' ML intelligence (score = overall aesthetic 0\u20131, detectedText = OCR-indexed text; null on macOS versions without them), iCloud shared-album social data (owner, comments, likes \u2014 only populated for shared assets), and type flags (HDR/live/raw/edited/portrait/panorama/etc.). Pass burstPhotos=true to also list the sibling frames of a burst (UUID, filename, date each).\nDo not use when: you don't have a UUID yet \u2014 use query to find matches first; you have several UUIDs \u2014 use get-photos for one batched call; or you want to see the image \u2014 use get-thumbnail.",
@@ -23301,7 +23309,7 @@ server.registerTool(
     return successResponse(lines.join("\n"), { photo: p });
   }, "get-photo")
 );
-server.registerTool(
+registerTool(
   "get-photos",
   {
     description: "Use when: you have SEVERAL UUIDs (typically from query or find-duplicates) and want full metadata for all of them \u2014 a dedupe review, an EXIF audit, a captioning pass. One batched sidecar round-trip (max 50 UUIDs) instead of N get-photo calls.\nReturns: count, photos (full per-photo detail \u2014 the same shape as get-photo, including the exif block, score, detectedText, and shared-album owner/comments/likes), and notFound listing any requested UUIDs that matched nothing.\nDo not use when: you have a single UUID \u2014 use get-photo; you don't have UUIDs yet \u2014 use query; or you want to see the images \u2014 use get-thumbnail per photo.",
@@ -23339,7 +23347,7 @@ ${lines.join("\n")}`,
     );
   }, "get-photos")
 );
-server.registerTool(
+registerTool(
   "get-thumbnail",
   {
     description: "Use when: you (or the user) want to SEE a photo \u2014 visual triage ('show me\u2026'), picking the best shot, eyeballing duplicate groups, or reading text in an image \u2014 without exporting anything to disk. Prefer this over export whenever the goal is to LOOK at a photo rather than to obtain the file.\nReturns: the photo as an inline MCP image content block (base64 JPEG/PNG a vision-capable client renders directly), plus a text summary and structured metadata (source path, width/height, MIME type, byte size, isDerivative). It serves the smallest Photos-generated preview derivative whose long edge is at least minSize pixels (default 360) \u2014 raise minSize (e.g. 1024) when you need detail like small text; isDerivative=false means no suitable derivative existed and the original was downscaled/converted via sips.\nDo not use when: you need the full-resolution file on disk \u2014 use export; or you only need metadata \u2014 use get-photo. Movies get a thumbnail only when Photos generated a poster-frame derivative; an iCloud-only photo with no local derivative or original cannot be thumbnailed (export it first, which downloads on demand).",
@@ -23372,7 +23380,7 @@ server.registerTool(
     );
   }, "get-thumbnail")
 );
-server.registerTool(
+registerTool(
   "get-selected-photos",
   {
     description: `Use when: the user says "these photos" / "the selected photos" \u2014 they have photos selected in the Photos.app window and you need their identities. This is the GUI-selection bridge: feed the returned UUIDs into get-photos, get-thumbnail, export, or add-to-album.
@@ -23412,7 +23420,7 @@ ${lines.join("\n")}`,
     );
   }, "get-selected-photos")
 );
-server.registerTool(
+registerTool(
   "find-duplicates",
   {
     description: "Use when: you want to find exact duplicates across the library \u2014 cleaning up after a double import, checking whether files were re-uploaded, or auditing before a migration/export.\nReturns: groupCount (total duplicate groups found), returned (groups in this response, capped at limit, default 100), and groups ordered newest-first \u2014 each with the member UUIDs plus per-member filename, date, size, dimensions, and movie flag. Use get-thumbnail on members to eyeball a group before acting on it.\nDo not use when: you're looking for near-duplicates or similar shots \u2014 Photos' fingerprint matches EXACT duplicates (identical image data) only; edited copies, resized versions, and burst siblings will NOT group.\nSafety: read-only. This server cannot delete photos \u2014 to act on duplicates, quarantine the extra copies into an album (create-album + add-to-album when writes are enabled, otherwise by hand in Photos.app) and review/delete inside Photos.app.",
@@ -23447,7 +23455,7 @@ server.registerTool(
 ${lines.join("\n")}`, { ...result });
   }, "find-duplicates")
 );
-server.registerTool(
+registerTool(
   "list-albums",
   {
     description: "Use when: you want the catalog of albums \u2014 e.g. to discover exact album names before filtering query by album, or to browse the library's organization.\nReturns: every album's title, folder path, photo count, shared status, and UUID.\nDo not use when: you want the photos inside an album \u2014 use query with the album filter; you want the folder hierarchy rather than albums \u2014 use list-folders; or you just want a total album count \u2014 use library-info.",
@@ -23470,7 +23478,7 @@ server.registerTool(
 ${lines.join("\n")}`, { count, albums });
   }, "list-albums")
 );
-server.registerTool(
+registerTool(
   "list-folders",
   {
     description: "Use when: you want the library's folder hierarchy \u2014 the containers that hold albums and subfolders \u2014 to understand how albums are nested.\nReturns: every folder's title, parent folder, album count, and subfolder count.\nDo not use when: you want the albums themselves (with their photo counts) \u2014 use list-albums; or you just want a total folder count \u2014 use library-info.",
@@ -23491,7 +23499,7 @@ server.registerTool(
 ${lines.join("\n")}`, { count, folders });
   }, "list-folders")
 );
-server.registerTool(
+registerTool(
   "list-keywords",
   {
     description: "Use when: you want the catalog of keywords (tags) in the library \u2014 e.g. to discover exact keyword spellings before filtering query by keyword, or to see which tags are most used. Pass limit for the top-N.\nReturns: keywords with their photo counts, sorted most-used first.\nDo not use when: you want photos carrying a keyword \u2014 use query with the keyword filter; or you want people/faces rather than tags \u2014 use list-persons.",
@@ -23513,7 +23521,7 @@ server.registerTool(
 ${lines.join("\n")}`, { count, keywords });
   }, "list-keywords")
 );
-server.registerTool(
+registerTool(
   "list-persons",
   {
     description: "Use when: you want the catalog of named people from Photos face recognition \u2014 e.g. to discover exact person names before filtering query by person, or to see who appears most. Pass limit for the top-N; unidentified faces appear as _UNKNOWN_.\nReturns: persons with their photo counts, sorted most-photographed first.\nDo not use when: you want photos of a person \u2014 use query with the person filter; or you want subject tags rather than people \u2014 use list-keywords.",
@@ -23535,7 +23543,7 @@ server.registerTool(
 ${lines.join("\n")}`, { count, persons });
   }, "list-persons")
 );
-server.registerTool(
+registerTool(
   "export",
   {
     description: "Use when: you want to copy one or more photos (by UUID, typically from query) out to a destination directory on disk. By default exports the original; set edited=true for the edited version, live=true to also include the live-photo video, raw=true to also include the raw image. Large batches report per-photo MCP progress notifications when the request carries a progressToken.\nReturns: the destination path, counts of files exported and skipped, the exported file paths, and a per-UUID reason for anything skipped (e.g. file already exists at the destination, UUID not found / in trash, iCloud download failed).\nDo not use when: you only need metadata or file paths rather than copies on disk \u2014 use get-photo; or you're still figuring out which photos to export \u2014 use query first.\nSafety: the only side-effecting tool on the read path \u2014 it writes files into the destination directory (created if missing); the opt-in write tools (APPLE_PHOTOS_MCP_ENABLE_WRITES=1) can also modify the library, but nothing else here writes anywhere. dest must resolve (after expanding ~ and following symlinks) to a path under your home directory, /tmp, /private/tmp, or /Volumes; anything else is rejected. With overwrite=true it OVERWRITES existing files of the same name in place; without it, existing files are skipped and reported per-UUID. If an original isn't on disk (iCloud 'Optimize Mac Storage'), the export falls back to driving Photos.app via AppleScript to download it on demand \u2014 this is slow for large batches and requires Photos.app installed, signed in to iCloud, and Automation permission granted.",
@@ -23607,7 +23615,7 @@ var writeAlbumOutput = {
     path: external_exports.string().optional()
   }).passthrough().optional()
 };
-server.registerTool(
+registerTool(
   "create-album",
   {
     description: "Use when: you need an album to file photos into \u2014 a new album by name, optionally nested inside a folder path (e.g. for a quarantine album before a dedupe review, or a per-trip album).\nReturns: album {uuid, name, path} and created \u2014 false means an album of that name already existed and was returned instead of creating a duplicate (idempotent: safe to re-run; without folder the name is matched anywhere in the library, with folder only inside that folder).\nDo not use when: you want to list existing albums \u2014 use list-albums; or you want to put photos into the album \u2014 follow up with add-to-album.\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Only creates albums/folders; never deletes, moves, or modifies photos. Drives Photos.app via AppleScript: Photos is launched if not running, and macOS Automation permission is required (one-time system prompt on first write). Writes always target the library currently open in Photos.app \u2014 there is no library parameter.",
@@ -23630,7 +23638,7 @@ server.registerTool(
     });
   }, "create-album")
 );
-server.registerTool(
+registerTool(
   "add-to-album",
   {
     description: "Use when: you have photo UUIDs (from query / find-duplicates) and want to file them into an album \u2014 e.g. collecting duplicate extras into a quarantine album, or filing a trip's photos.\nReturns: the album {uuid, name, path}, addedCount, added (UUIDs newly added), alreadyPresent (UUIDs that were already members \u2014 adding is idempotent), and notFound (requested UUIDs that don't exist in the library). Fails only when the album doesn't exist or NO requested photo exists.\nDo not use when: the album doesn't exist yet \u2014 call create-album first; or you want photos OUT of an album \u2014 use remove-from-album.\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Changes album membership only: photos are never copied, modified, or deleted, and each target is validated to exist first. Max 100 UUIDs per call. Drives Photos.app via AppleScript (launches it if needed; requires macOS Automation permission \u2014 one-time prompt). Writes target the library currently open in Photos.app.",
@@ -23661,7 +23669,7 @@ server.registerTool(
     return successResponse(lines.join("\n"), { ...result });
   }, "add-to-album")
 );
-server.registerTool(
+registerTool(
   "remove-from-album",
   {
     description: "Use when: you want to take photos OUT of an album \u2014 undoing a mis-filing, or clearing reviewed items from a quarantine album. This removes ALBUM MEMBERSHIP only.\nReturns: the album AFTER the operation ({uuid, name, path} \u2014 note the uuid CHANGES when anything was removed), removedCount, removed, notInAlbum (requested UUIDs that weren't members \u2014 no-ops), albumRecreated, and previousAlbumUuid.\nDo not use when: you want to delete photos from the library \u2014 this server cannot delete photos at all (quarantine them in an album and review in Photos.app instead); or the photos aren't in the album (harmless, but pointless).\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). NEVER deletes photos from the library \u2014 removed photos stay in All Photos and every other album. Photos' AppleScript has no remove-from-album verb, so the album is REBUILT (same name and remaining photos): its UUID changes and any custom manual sort order is lost; re-fetch the album UUID from the response. When none of the UUIDs are members, nothing is rebuilt. The replacement is built under a scratch name `apple-photos-mcp-tmp-<hex>` and renamed last, so a call killed mid-rebuild (e.g. the 10-minute budget expiring while copying a very large album) leaves the original album and every photo intact but can strand an `apple-photos-mcp-tmp-\u2026` album to delete in Photos.app; each interrupted run strands a distinct one. Max 100 UUIDs per call. Drives Photos.app via AppleScript (requires macOS Automation permission). Writes target the library currently open in Photos.app.",
@@ -23695,7 +23703,7 @@ server.registerTool(
     return successResponse(lines.join("\n"), { ...result });
   }, "remove-from-album")
 );
-server.registerTool(
+registerTool(
   "set-photo-metadata",
   {
     description: "Use when: you want to set a photo's title, description, or favorite flag \u2014 captioning passes, marking the best shot of a burst, titling scans.\nReturns: uuid, updated (which fields were written), and the full before/after values of all three fields \u2014 so any change can be reverted by writing the before values back.\nDo not use when: you want keywords \u2014 use set-keywords (it has union semantics; this tool doesn't touch keywords); or you only want to READ metadata \u2014 use get-photo.\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Metadata only \u2014 never touches the image asset, and only the fields you pass are modified (an empty string clears title/description). The target photo is validated to exist first. Drives Photos.app via AppleScript (requires macOS Automation permission). Writes target the library currently open in Photos.app.",
@@ -23724,7 +23732,7 @@ server.registerTool(
     return successResponse(lines.join("\n"), { ...result });
   }, "set-photo-metadata")
 );
-server.registerTool(
+registerTool(
   "set-keywords",
   {
     description: "Use when: you want to add and/or remove keywords (tags) on a photo \u2014 tagging workflows, fixing a mis-tag \u2014 without disturbing its other keywords.\nReturns: uuid, before/after keyword lists (revert by re-running with the diff inverted), added and removed (what actually changed \u2014 adding an existing keyword or removing an absent one is a no-op), and changed.\nDo not use when: you want to browse keywords \u2014 use list-keywords; or find photos by keyword \u2014 use query. A keyword passed in both add and remove is rejected.\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). UNION semantics \u2014 the photo's current keywords are read first and edits are merged in, so existing keywords you don't mention are ALWAYS preserved (never a blind replace). Metadata only \u2014 the image asset is untouched; the target photo is validated to exist first. Drives Photos.app via AppleScript (requires macOS Automation permission). Writes target the library currently open in Photos.app.",
@@ -23754,7 +23762,7 @@ server.registerTool(
     return successResponse(lines.join("\n"), { ...result });
   }, "set-keywords")
 );
-server.registerTool(
+registerTool(
   "set-photo-date",
   {
     description: "Use when: a photo's date/time is wrong and you want to fix it \u2014 trailcam or scanner imports stamped with the upload time, a camera with a mis-set clock, scanned prints. Set an absolute date OR shift by a number of seconds (exactly one of date / shiftSeconds). DRY RUN BY DEFAULT: with dryRun omitted (or true) it only reports the current and would-be dates \u2014 preview first, then re-run with dryRun=false to write.\nReturns: uuid, before and after datetimes (on a dry run, after = the would-be date), shiftSeconds (the effective delta), applied, and dryRun. Revert an applied change by re-running with date=<the echoed before> and dryRun=false.\nDo not use when: you want to find photos by date \u2014 use query; or you expect the file's EXIF to change \u2014 this edits the Photos library date only.\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Rewrites the photo's date in the Photos LIBRARY DATABASE only \u2014 the same operation as Photos.app's 'Adjust Date & Time'; the original file's EXIF is never modified. Dates are interpreted in the Mac's local timezone (a timezone-aware ISO datetime is converted to local). Nothing is written unless dryRun=false is passed explicitly, and before/after are always echoed so any change can be reverted. The target photo is validated to exist first. Drives Photos.app via AppleScript (requires macOS Automation permission). Writes target the library currently open in Photos.app.",
@@ -23790,7 +23798,7 @@ server.registerTool(
     return successResponse(lines.join("\n"), { ...result });
   }, "set-photo-date")
 );
-server.registerTool(
+registerTool(
   "import-photos",
   {
     description: "Use when: you have image/video files on disk that belong in the Photos library \u2014 round-trip edits (export \u2192 fix \u2192 import), a folder of scans, an SD-card ingest \u2014 optionally filed straight into an existing album.\nReturns: requestedCount (validated source files), importedCount, imported (uuid + filename per new item \u2014 feed into get-photos / add-to-album / set-photo-date), and the album when one was targeted. importedCount < requestedCount usually means Photos skipped duplicates.\nDo not use when: the target album doesn't exist yet \u2014 call create-album first (a missing album is an error, not auto-created); or the files are outside your home directory, /tmp, /private/tmp, or /Volumes \u2014 those paths are rejected.\nSafety: WRITE tool \u2014 disabled unless APPLE_PHOTOS_MCP_ENABLE_WRITES=1 (run doctor to check). Only ADDS to the library \u2014 never modifies or deletes anything; source files stay where they are (Photos copies them in). But note the reverse door is closed: Photos' AppleScript has no photo-delete verb, so an import cannot be programmatically undone \u2014 removing a mistaken import requires Photos.app by hand. Every path is validated (absolute, exists, allowed root) before anything imports. Duplicate checking is ON by default; a duplicate then makes Photos.app show a BLOCKING dialog a human must answer (the call waits up to its timeout) \u2014 set skipDuplicateCheck=true only when duplicates are acceptable, because they WILL be re-added silently. Drives Photos.app via AppleScript (requires macOS Automation permission; launches Photos if needed). Imports go into the library currently open in Photos.app.",

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos-mcp",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Photos - query, search, export, and inspect the macOS Photos library via Claude and other AI assistants, plus opt-in album/metadata write tools (read-only by default)",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  McpServer,
+  type RegisteredTool,
+  type ToolCallback,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { readFileSync } from "node:fs";
@@ -62,7 +67,52 @@ const uuidSchema = z
   );
 
 // --- health-check ---
-server.registerTool(
+/**
+ * Register a tool, advertising its `outputSchema` as PERMISSIVE.
+ *
+ * The MCP **client** validates a result's `structuredContent` against the JSON
+ * Schema the server advertised — not against the server's own zod object. A
+ * bare zod raw shape renders as `additionalProperties: false`, so a payload
+ * carrying any field the schema didn't enumerate is rejected client-side with
+ * `-32602 … data must NOT have additional properties`, discarding a result the
+ * handler produced correctly. The server never sees it, because zod's own parse
+ * silently *strips* unknown keys rather than failing — which is why the
+ * registerTool/outputSchema migration's "all fields optional, no `.strict()`"
+ * was believed to be permissive. It covered optionality; it did not cover
+ * undeclared keys.
+ *
+ * `.passthrough()` advertises `additionalProperties: true`, which is the
+ * contract that migration intended: a declared field documents the shape, an
+ * undeclared one is carried through instead of nuking the whole result. This is
+ * not hypothetical — it took down `get-mail-stats` in the sibling
+ * apple-mail-mcp (sweetrb/apple-mail-mcp#135), where every tool was likewise
+ * advertising `additionalProperties: false` and the one tool whose payload
+ * carried an undeclared key failed on every call. Enforced for every tool here
+ * by the outputSchema contract test.
+ */
+function registerTool<
+  OutputArgs extends z.ZodRawShape,
+  InputArgs extends undefined | z.ZodRawShape = undefined,
+>(
+  name: string,
+  config: {
+    title?: string;
+    description?: string;
+    inputSchema?: InputArgs;
+    outputSchema?: OutputArgs;
+    annotations?: ToolAnnotations;
+  },
+  cb: ToolCallback<InputArgs>
+): RegisteredTool {
+  const { outputSchema, ...rest } = config;
+  return server.registerTool(
+    name,
+    outputSchema ? { ...rest, outputSchema: z.object(outputSchema).passthrough() } : rest,
+    cb
+  );
+}
+
+registerTool(
   "health-check",
   {
     description:
@@ -84,7 +134,7 @@ server.registerTool(
 );
 
 // --- doctor ---
-server.registerTool(
+registerTool(
   "doctor",
   {
     description:
@@ -114,7 +164,7 @@ server.registerTool(
 );
 
 // --- library-info ---
-server.registerTool(
+registerTool(
   "library-info",
   {
     description:
@@ -153,7 +203,7 @@ server.registerTool(
 );
 
 // --- query ---
-server.registerTool(
+registerTool(
   "query",
   {
     description:
@@ -366,7 +416,7 @@ server.registerTool(
 );
 
 // --- get-photo ---
-server.registerTool(
+registerTool(
   "get-photo",
   {
     description:
@@ -447,7 +497,7 @@ server.registerTool(
 );
 
 // --- get-photos ---
-server.registerTool(
+registerTool(
   "get-photos",
   {
     description:
@@ -488,7 +538,7 @@ server.registerTool(
 );
 
 // --- get-thumbnail ---
-server.registerTool(
+registerTool(
   "get-thumbnail",
   {
     description:
@@ -535,7 +585,7 @@ server.registerTool(
 );
 
 // --- get-selected-photos ---
-server.registerTool(
+registerTool(
   "get-selected-photos",
   {
     description:
@@ -576,7 +626,7 @@ server.registerTool(
 );
 
 // --- find-duplicates ---
-server.registerTool(
+registerTool(
   "find-duplicates",
   {
     description:
@@ -625,7 +675,7 @@ server.registerTool(
 );
 
 // --- list-albums ---
-server.registerTool(
+registerTool(
   "list-albums",
   {
     description:
@@ -651,7 +701,7 @@ server.registerTool(
 );
 
 // --- list-folders ---
-server.registerTool(
+registerTool(
   "list-folders",
   {
     description:
@@ -676,7 +726,7 @@ server.registerTool(
 );
 
 // --- list-keywords ---
-server.registerTool(
+registerTool(
   "list-keywords",
   {
     description:
@@ -701,7 +751,7 @@ server.registerTool(
 );
 
 // --- list-persons ---
-server.registerTool(
+registerTool(
   "list-persons",
   {
     description:
@@ -726,7 +776,7 @@ server.registerTool(
 );
 
 // --- export ---
-server.registerTool(
+registerTool(
   "export",
   {
     description:
@@ -864,7 +914,7 @@ const writeAlbumOutput = {
 };
 
 // --- create-album ---
-server.registerTool(
+registerTool(
   "create-album",
   {
     description:
@@ -899,7 +949,7 @@ server.registerTool(
 );
 
 // --- add-to-album ---
-server.registerTool(
+registerTool(
   "add-to-album",
   {
     description:
@@ -944,7 +994,7 @@ server.registerTool(
 );
 
 // --- remove-from-album ---
-server.registerTool(
+registerTool(
   "remove-from-album",
   {
     description:
@@ -992,7 +1042,7 @@ server.registerTool(
 );
 
 // --- set-photo-metadata ---
-server.registerTool(
+registerTool(
   "set-photo-metadata",
   {
     description:
@@ -1031,7 +1081,7 @@ server.registerTool(
 );
 
 // --- set-keywords ---
-server.registerTool(
+registerTool(
   "set-keywords",
   {
     description:
@@ -1075,7 +1125,7 @@ server.registerTool(
 );
 
 // --- set-photo-date ---
-server.registerTool(
+registerTool(
   "set-photo-date",
   {
     description:
@@ -1137,7 +1187,7 @@ server.registerTool(
 );
 
 // --- import-photos ---
-server.registerTool(
+registerTool(
   "import-photos",
   {
     description:

--- a/test/output-schema.test.ts
+++ b/test/output-schema.test.ts
@@ -73,6 +73,33 @@ describe("outputSchema contract (real server over stdio)", () => {
     ).toEqual([]);
   });
 
+  it("every outputSchema tolerates undeclared keys (additionalProperties !== false)", async () => {
+    // The CLIENT validates structuredContent against the ADVERTISED JSON Schema
+    // (client/index.js -> "Structured content does not match the tool's output
+    // schema"), so `additionalProperties: false` makes any field the schema
+    // didn't enumerate a hard -32602 that discards an otherwise-correct result.
+    // The server never notices, because zod's own parse strips unknown keys
+    // instead of failing — so nothing but this assertion catches it. A bare zod
+    // raw shape renders as additionalProperties:false; registerTool() in
+    // src/index.ts wraps every shape in .passthrough() to prevent that.
+    // Not hypothetical: this took down get-mail-stats in the sibling
+    // apple-mail-mcp (sweetrb/apple-mail-mcp#135).
+    const { tools } = await client.listTools();
+    const offenders = tools
+      .filter(
+        (t) =>
+          (t.outputSchema as { additionalProperties?: unknown } | undefined)
+            ?.additionalProperties === false
+      )
+      .map((t) => t.name);
+    expect(
+      offenders,
+      `outputSchemas must tolerate undeclared keys — these advertise ` +
+        `additionalProperties:false, so any field they don't enumerate is rejected ` +
+        `client-side and the whole result is lost: ${offenders.join(", ")}`
+    ).toEqual([]);
+  });
+
   it("diagnostic tools' real output validates against their outputSchema (when reachable)", async () => {
     // The SDK throws an "Output validation error" McpError when a success
     // result's structuredContent is missing or fails its schema — the only


### PR DESCRIPTION
Propagates the schema half of sweetrb/apple-mail-mcp#135 to this repo. Same defect, same fix, verified the same way.

## The defect

The MCP **client** validates a result's `structuredContent` against the JSON Schema the server *advertised* — not against the server's own zod object. A bare zod raw shape renders as `additionalProperties: false`, so any field a handler emits that its schema doesn't enumerate becomes a hard client-side `-32602 … data must NOT have additional properties`, discarding a payload the handler computed correctly.

The server never notices, because zod's own parse silently **strips** unknown keys instead of failing. That is exactly why the `registerTool`/`outputSchema` migration's "all fields optional, no `.strict()`" was believed permissive: it covered optionality, it did not cover undeclared keys.

## Why it matters here

In apple-mail-mcp this was **not** latent — it broke `get-mail-stats` on every call for anyone with IMAP configured, because that tool's IMAP branch spreads an object carrying a `perMailbox` key the schema never declared. Measuring every repo in the family showed the same advertisement everywhere:

| repo | tools advertising `additionalProperties: false` (before) |
|---|---|
| apple-mail-mcp | 50 of 50 — fixed in 2.10.6 |
| apple-notes-mcp | 36 of 36 |
| apple-photos-mcp | 21 of 21 |
| apple-numbers-mcp | 26 of 26 |

So in this repo it is currently latent: it costs nothing until some handler's payload gains a key its schema doesn't list, at which point that tool fails **completely** rather than degrading — and CI would stay green while it happened.

## The fix

Every tool registers through a wrapper that wraps its shape in `.passthrough()`, advertising `additionalProperties: true` — the contract the migration intended. A declared field still documents the shape; an undeclared one is carried through instead of nuking the result. No tool signature, parameter or behaviour changes.

## The guard

The outputSchema contract test now fails any tool advertising `additionalProperties: false`. The existing assertions couldn't see this class: they check that every tool *has* a schema and that none *requires* a field, then round-trip only the diagnostic tools — so a tool with an undeclared key passes CI and fails in the user's client. Verified a real guard rather than a tautology: it reports every tool in this repo as an offender before the fix and none after.

## Verification

- `typecheck`, `lint`, `format:check` clean; full unit suite passes
- outputSchema contract suite passes against the freshly built bundle
- Booted the built bundle over stdio and confirmed `additionalProperties: false` count went to **0**
- Committed bundle rebuilt and in sync