### PR TITLE
ci: close two CHANGELOG holes in version-guard (heading deletion, Unreleased drain)

### DIFF
--- a/.github/workflows/version-guard.yml
+++ b/.github/workflows/version-guard.yml
@@ -120,6 +120,55 @@ jobs:
           newv="$(node -e 'console.log(require("./package.json").version)')"
           echo "package.json version: base=${oldv}  head=${newv}"
 
+          # ── CHANGELOG history is append-only ──────────────────────────────
+          # The rule below only proves the NEW version has a heading. A PR that
+          # RENAMES an existing heading instead of adding one satisfies it while
+          # ERASING a published release: retitling "## [1.1.12] - 2026-08-03"
+          # to "## [1.1.13] - 2026-08-04" leaves 1.1.13 documented and 1.1.12
+          # gone. Not hypothetical — apple-numbers-mcp #54 did exactly that, and
+          # since nothing downstream reads CHANGELOG.md it stayed invisible
+          # until an audit found the one missing heading across every published
+          # version in the four repos.
+          # So: every "## [X.Y.Z]" heading present at the base must still be
+          # present here. Adding is free; renaming or deleting one fails.
+          # Compared against the CHECKED-OUT tree — the merge result under
+          # pull_request, HEAD under workflow_dispatch — so a branch that is
+          # merely stale (main released while the PR sat open) is never blamed
+          # for headings it has not merged yet.
+          if [ ! -f CHANGELOG.md ]; then
+            echo "::error::CHANGELOG.md is missing from this branch. It is the only record of what each published version contains — restore it."
+            exit 1
+          fi
+          # Reading the base copy needs real history. The checkout above pins
+          # fetch-depth: 0; deepen defensively, then refuse to run rather than
+          # pass unevaluated, so a future edit to that input cannot silently
+          # turn this check into a no-op.
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --no-tags --quiet --unshallow || true
+          fi
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::Base commit ${BASE_SHA} is not present in this clone (shallow checkout?), so the CHANGELOG history check cannot be evaluated. Restore 'fetch-depth: 0' on the checkout step."
+            exit 1
+          fi
+          if git cat-file -e "${BASE_SHA}:CHANGELOG.md" 2>/dev/null; then
+            base_heads="$(git show "${BASE_SHA}:CHANGELOG.md" | sed -nE 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/p')"
+            head_heads="$(sed -nE 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/p' CHANGELOG.md)"
+            # Loop + `grep -qxF` rather than `comm`: no sort-order or locale
+            # assumptions, and a version string is full of regex metacharacters.
+            lost=""
+            while IFS= read -r v; do
+              [ -n "$v" ] || continue
+              printf '%s\n' "$head_heads" | grep -qxF -- "$v" || lost="${lost}${v} "
+            done <<< "$base_heads"
+            if [ -n "$lost" ]; then
+              echo "::error::CHANGELOG.md no longer has a '## [X.Y.Z]' heading for release(s) documented on the base: ${lost% }. A published release's section must never be renamed, retitled or removed — add a NEW heading for this release and restore the one(s) above."
+              exit 1
+            fi
+            echo "CHANGELOG.md preserves every release heading present on the base."
+          else
+            echo "::notice::No CHANGELOG.md at the base commit — no release headings to preserve."
+          fi
+
           if [ "$oldv" != "$newv" ]; then
             # Bump present: require it to be an increase (typo'd downgrades)…
             OLDV="$oldv" NEWV="$newv" node -e '
@@ -159,6 +208,27 @@ jobs:
               exit 1
             fi
             echo "CHANGELOG.md documents ${newv}."
+
+            # …and require "## [Unreleased]" to be EMPTY. The heading check
+            # above proves the new version is documented somewhere; it says
+            # nothing about notes still parked under "## [Unreleased]", which
+            # this release drains: everything on main ships in the next publish,
+            # so prose left under that marker describes released behaviour while
+            # claiming to be unreleased, and nothing later renames the section.
+            # Until now nothing guarded that at all. dependabot-rebuild.yml
+            # inserts its "## [X.Y.Z]" heading directly BELOW the marker and
+            # leaves it empty, so bot PRs pass unchanged.
+            if [ -z "$(awk 'index($0,"## [Unreleased]")==1{print "y"; exit}' CHANGELOG.md)" ]; then
+              echo "::error::CHANGELOG.md has no '## [Unreleased]' heading. Keep an empty one at the top — dependabot-rebuild.yml hard-exits without that marker, so dropping it silently breaks the Dependabot rebuild + auto-bump path."
+              exit 1
+            fi
+            unrel="$(awk 'index($0,"## [Unreleased]")==1{u=1;next} u&&index($0,"## ")==1{exit} u{print}' CHANGELOG.md)"
+            if [ -n "$(printf '%s' "$unrel" | tr -d '[:space:]')" ]; then
+              echo "::error::Version is bumped to ${newv} but '## [Unreleased]' is not empty. This release publishes everything on main, so those notes ship as ${newv} while sitting under a heading that says they are unreleased — and nothing renames that section later. Move them under '## [${newv}] - $(date -u +%Y-%m-%d)' and leave '## [Unreleased]' empty. Content found:"
+              printf '%s\n' "$unrel" | sed 's/^/  /'
+              exit 1
+            fi
+            echo "'## [Unreleased]' is empty."
           fi
 
           if [ -z "$code" ] && [ -z "$deps_changed" ]; then


### PR DESCRIPTION
## What

`version-guard` already proves a bumped version **has** a `## [X.Y.Z]` heading. Two ways to satisfy that rule while still losing the record stayed open. This closes both.

**CI-only change — `.github/` does not ship, so no version bump is owed.**

### Hole 1 — heading deletion (checked *outside* the bump branch)

A PR that **renames** an existing heading instead of adding one passes the current rule while **erasing a published release**: retitling `## [1.1.12] - 2026-08-03` to `## [1.1.13] - 2026-08-04` leaves 1.1.13 documented and 1.1.12 gone.

Not hypothetical — **apple-numbers-mcp #54 did exactly that.** Because nothing downstream reads `CHANGELOG.md`, it stayed invisible until an audit found the one missing heading across every published version in the four repos.

Now: every `## [X.Y.Z]` heading present at the base must still be present. Adding is free; renaming or deleting one fails. This lives **outside** the `oldv != newv` branch deliberately — a rename can land in a PR that bumps (numbers #54 did) or one that does not.

### Hole 2 — `## [Unreleased]` drain (checked *inside* the bump branch)

Nothing guarded notes left under `## [Unreleased]` on a bumping PR. The release publishes everything on main, so those notes ship as the new version while sitting under a heading that says they are unreleased — and nothing renames that section later.

Now a bump requires the section to be **empty**, and requires the **marker itself to still exist** (`dependabot-rebuild.yml` hard-exits without it). The error prints the offending content indented so the fix is obvious.

## Design

- **The head side reads the CHECKED-OUT TREE**, deliberately not `git show "${HEAD_SHA}:CHANGELOG.md"`. Under `pull_request` the checkout is the merge commit, so a branch left open across a release already contains main's newer headings — reading `HEAD_SHA` would **false-fail every stale PR**. Under `workflow_dispatch` the tree *is* HEAD and BASE is the `origin/main` fork point (an ancestor), so base headings are a subset unless the branch deleted one. This also matches existing style: the current CHANGELOG check and `newv` already read the working tree.
- **Membership via `while read` + `grep -qxF`, not `comm`** — no sort-order or locale assumptions, and version strings are full of regex metacharacters (copying `conformance-check.sh`'s documented reasoning).
- **Both `Unreleased` checks use `index($0,"## [Unreleased]")==1`** — `conformance-check.sh`'s own idiom — avoiding awk `\[` escape portability questions. The terminator `index($0,"## ")==1` correctly ignores `### Fixed` sub-headings.

### Edge cases, explicit

| Case | Behaviour |
|---|---|
| Shallow checkout | deepen via `--unshallow`, then **hard-fail** if the base commit is still unreachable — never skip. Skipping would be the same false-pass class `conformance-check.sh`'s PyYAML / uniform-deletion preflights exist to prevent. |
| `CHANGELOG.md` absent at base (first commit) | `::notice::` and continue — nothing to preserve. Distinguished from an unreachable base commit, which fails. |
| `CHANGELOG.md` deleted by the PR | explicit hard fail — it is the maximal heading deletion, and would otherwise crash `sed` under `set -e` with a cryptic message. |
| `set -euo pipefail` | every new pipeline is either an `if`/`\|\|` condition or ends in a command that cannot fail (`sed`/`awk`/`tr`). No unguarded pipefail exits. |

## Verification

Run against **this repo's real `CHANGELOG.md` (24 release headings)**, executing the actual `run:` block extracted from the parsed YAML — not a paraphrase. Synthetic repos carry this repo's real `.gitignore`, so `build/` tracking matches production (without it the shipped-bytes case silently false-passes, since Rob's global gitignore ignores `build/`).

| Case | Expected | Result |
|---|---|---|
| no-op PR | pass | ✅ preserves every heading |
| **rename `## [2.1.8]` → `## [2.1.10]`** (the numbers #54 class) | fail | ✅ names `2.1.8` |
| `CHANGELOG.md` deleted | fail | ✅ |
| proper release (new heading, empty `Unreleased`) | pass | ✅ both blocks |
| bump with notes left under `## [Unreleased]` | fail | ✅ drain error |
| same content, **no bump** | pass | ✅ block 2 correctly scoped to bumps |
| `## [Unreleased]` marker deleted + bump | fail | ✅ dependabot rationale |
| heading **date** edited, version preserved | pass | ✅ no false positive |
| pre-existing "shipped bytes changed, no bump" | fail | ✅ unchanged behaviour |

Also verified:

- **`dependabot-rebuild.yml`'s exact auto-bump snippet** run against this repo's `CHANGELOG.md`: 24 → 25 headings, all three rules PASS. **Bot PRs are unaffected**, including this repo's leading `# Changelog` title line.
- YAML parses (PyYAML); `bash -n` clean; `pnpm lint`, `typecheck`, `format:check` clean; **290/290 unit tests pass**.
- `pnpm install --frozen-lockfile` in a clean external clone rebuilt `build/index.js` **byte-identical** — no bundle drift.

## Scope and coupling

**Pure insertion — 70 added lines, 0 removed or altered.** Workflow `name: version-guard`, job key `require-version-bump`, and both triggers (`pull_request`, `workflow_dispatch`) untouched, so the required `require-version-bump` context and `conformance-check.sh`'s IDENTICAL set are unaffected. The patch is byte-identical across all four repos.

> **Note:** the optional header-comment edit was **deliberately skipped.** `version-guard.yml` is in `conformance-check.sh`'s byte-identical set, and only a *description* of that edit was specified — no exact wording. Four repos patched in parallel would each have invented different prose, guaranteeing `DRIFT: .github/workflows/version-guard.yml differs`. Worth landing later as one deliberate four-repo pass with fixed wording.

## Known trade-off

**Archiving old entries OUT of `CHANGELOG.md` now fails.** That is intentional and documented inline — the file is the only record of what each published version contains, and the guard cannot distinguish deliberate archival from the rename that erased 1.1.12.

Second-order effect worth knowing: if `## [Unreleased]` on main ever became non-empty, every bumping PR (including Dependabot's) would fail until the notes are filed. That *is* the drain being enforced, it fails loudly rather than silently, and all four repos have an empty `## [Unreleased]` on main today.
