### PR TITLE
fix: advertise JSON Schema 2020-12 for every tool schema (2.1.10)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "source": {
         "source": "local",
         "path": "./codex"

--- a/.antigravity-plugin/marketplace.json
+++ b/.antigravity-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "apple-photos",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
       "source": {
         "source": "local",

--- a/.antigravity-plugin/plugin.json
+++ b/.antigravity-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "apple-photos-mcp",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Apple Photos integration for Claude Code via MCP",
   "owner": {
     "name": "Rob Sweet",
@@ -11,7 +11,7 @@
     {
       "name": "apple-photos",
       "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only)",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "author": {
         "name": "Rob Sweet",
         "email": "rob@superiortech.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only)",
   "author": {
     "name": "Rob Sweet",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,23 @@
 
 ## [Unreleased]
 
+## [2.1.10] - 2026-08-12
+
+### Fixed
+
+- **Every tool was refused by the client, because all 42 advertised schemas declared JSON Schema draft-07.** MCP has standardized on **JSON Schema 2020-12**, and clients now reject anything else outright — `Tool '<name>' has an invalid outputSchema: JSON Schema declares an unsupported dialect ("$schema": "http://json-schema.org/draft-07/schema#"). The default validator supports JSON Schema 2020-12 only.` The server connected fine; not one of its 21 tools was usable. The dialect is not ours to choose at the registration site: the SDK's `server/mcp.js` calls `toJsonSchemaCompat(obj, { strictUnions, pipeStrategy })` with **no `target`**, so `mapMiniTarget(undefined)` resolves to `'draft-7'` and both the emitted `inputSchema` and `outputSchema` are stamped draft-07. Upgrading zod does **not** fix it — the v4 (`zod/v4-mini` `toJSONSchema`) branch falls back to the same target, verified empirically against SDK 1.30.0 + zod 4.4.3 — so this is fixed at the transport boundary instead, the only public seam that does not reach into SDK internals: `src/index.ts` wraps the stdio transport in `withJsonSchema2020_12()`, which rewrites the outgoing `tools/list` payload. The converter also handles the keywords whose spelling changed in 2020-12 (`definitions` → `$defs` and the `#/definitions/` refs pointing at it, tuple `items` → `prefixItems`, `additionalItems` → `items`, `dependencies` → `dependentRequired`/`dependentSchemas`, boolean `exclusiveMinimum`/`exclusiveMaximum` → numeric). None of those paths is reachable from today's schemas — they are already dialect-portable, and the rewritten payload is byte-identical to the old one once `$schema` is stripped — so the conversion is a no-op in practice and exists so the seam stays correct if a new zod construct ever introduces one. Origin: sweetrb/apple-mail-mcp#147; fixed identically in all four servers.
+
+### Added
+
+- **The outputSchema contract test now pins the advertised dialect.** Two assertions against the real built server over stdio: every `inputSchema`/`outputSchema` must declare `https://json-schema.org/draft/2020-12/schema`, and no advertised schema may contain a draft-07-only construct (a `draft-07` mention anywhere, a `#/definitions/` `$ref`, a `definitions`/`additionalItems`/`dependencies` keyword, a boolean `exclusiveMinimum`/`exclusiveMaximum`, or a `$schema` on any node but the root). The existing checks could not see this class at all — they inspect schema *contents*, and a schema can be perfectly shaped while declaring a dialect that makes the client discard the tool before it is ever called. A new unit suite covers the converter itself, including the cases today's schemas do not exercise.
+
+### Documentation
+
+- **README's Troubleshooting section now carries the "unsupported dialect" symptom** with the exact error text and the fix (upgrade to 2.1.10, restart the host app), since a user on any earlier version sees it on every tool and has no other way to connect it to a server version. The Architecture section states that schemas are advertised as 2020-12 and points at the normalizer, and CONTRIBUTING.md records the wrapper as load-bearing — it is a `transport.send` interception with no local caller, exactly the shape a later cleanup would remove without knowing that doing so makes the whole server unusable.
+
 ### Security
 
 - **Bumped the pinned `pnpm/action-setup` to v6.0.10 and `github/codeql-action/*` to v4.37.6.** Dependabot's weekly `github-actions` group PR landed these in apple-mail-mcp (#146) and apple-numbers-mcp (#62) but **skipped this repo**, so `conformance-check.sh` reported drift in `ci.yml`, `publish.yml`, `dependabot-rebuild.yml`, `codeql.yml` and `scorecard.yml`. The four servers are meant to carry a byte-identical workflow set, and a silent group-skip is the recurring way that breaks — this is the same failure recorded for the scorecard pin in 2026-08-05. `.github/` does not ship, so this owes no version bump.
-
-### Security
 
 - **Floored `js-yaml` to `^4.3.1`, clearing GHSA-5p4m-2wfm-xmqj (high).** Quadratic CPU consumption while resolving `!!omap` keys — a malicious YAML document can be made to burn CPU superlinearly in the number of map entries. The advisory notes the CVE-2026-59870 fix was never backported to the 3.x line, so 4.3.1 is the first complete release. `js-yaml` reaches the tree as `eslint` -> `js-yaml`, which is **development scope**, and it does not appear in the committed `build/index.js` — verified, 0 references — so no published artifact ever carried it and this owes no version bump. No `js-yaml` override existed here before; apple-mail-mcp carried one pinned at `^4.2.0` — below this fix — which is how the gap was found.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,10 @@ When adding a new MCP tool:
 - Surface sidecar failures as the JSON `{"error": ...}` envelope; keep stdout pure JSON.
 - Permission/Full-Disk-Access failures should point users at the `doctor` tool and the remediation in `docs/FULL-DISK-ACCESS.md`.
 
+## Tool schemas are normalized to JSON Schema 2020-12
+
+`src/index.ts` wraps the stdio transport in `withJsonSchema2020_12()` (`src/utils/jsonSchemaDialect.ts`), which rewrites every `inputSchema`/`outputSchema` in the outgoing `tools/list` payload to declare JSON Schema 2020-12. **Do not remove that wrapper.** The MCP SDK calls its zod converter without a target, so both its zod v3 and v4 branches emit `"$schema": "http://json-schema.org/draft-07/schema#"` — and clients now refuse any tool that advertises a dialect other than 2020-12, which makes the whole server unusable. Upgrading zod does not fix it. New tools need nothing special; the normalizer is generic and `test/output-schema.test.ts` asserts the contract against the real built server.
+
 ## Questions?
 
 Open an issue for any questions about contributing.

--- a/README.md
+++ b/README.md
@@ -926,7 +926,7 @@ non-secret config here.
 
 This package is a **TypeScript MCP server with a Python sidecar**:
 
-- The MCP server (Node) speaks the Model Context Protocol over stdio.
+- The MCP server (Node) speaks the Model Context Protocol over stdio. Every tool's `inputSchema` and `outputSchema` is advertised as **JSON Schema 2020-12** — the dialect MCP standardized on and the only one modern clients will validate against. The MCP SDK's zod converter still emits draft-07, so the outgoing `tools/list` payload is normalized at the transport boundary (`src/utils/jsonSchemaDialect.ts`).
 - A bundled Python script (`src/utils/photos_reader.py`) uses `osxphotos` to read the Photos library and returns JSON.
 - The sidecar runs as a **persistent process** (`photos_reader.py --serve`): the TypeScript side spawns it once on first use and sends it line-delimited JSON requests over stdin, behind a serial gate (exactly one request in flight at a time). The Node event loop stays free, so the server keeps answering MCP traffic (pings, `health-check`, `doctor`) even during a long `query` or a minutes-long iCloud `export`.
 - If serve mode is unavailable (old script, broken environment), the server transparently falls back to spawning a fresh one-shot Python process per call — same results, same error messages, just slower. `doctor`'s `sidecar_mode` check reports which mode is active.
@@ -1015,6 +1015,11 @@ For the full rundown — read-only scope, iCloud export caveats, face/album beha
 
 ### Photos.app errors when running
 - Closing Photos.app may resolve database-lock errors. osxphotos opens the library in read-only mode but still requires that no writer holds an exclusive lock.
+
+### Every tool is rejected: "invalid outputSchema … unsupported dialect"
+- The full message is `Tool '<name>' has an invalid outputSchema: JSON Schema declares an unsupported dialect ("$schema": "http://json-schema.org/draft-07/schema#"). The default validator supports JSON Schema 2020-12 only.` The server connects, but no tool is usable.
+- **Upgrade to apple-photos-mcp 2.1.10 or later** (`npx -y apple-photos-mcp@latest`, or `pnpm run build` from a clone) and restart the host app. Versions up to 2.1.9 advertised draft-07 schemas because the MCP SDK's zod converter emits that dialect; 2.1.10 normalizes every advertised schema to 2020-12.
+- Nothing else changes — no tool, parameter, or result differs between the two dialects for this server.
 
 ### `apple-photos` server fails to connect when run from a clone
 - **Launch `claude` from inside the repo directory** so `CLAUDE_PROJECT_DIR` resolves to the repo root. The bare `.` fallback resolves against the launching process's working directory, not the repo, and is unreliable.

--- a/build/index.js
+++ b/build/index.js
@@ -22722,6 +22722,95 @@ var PhotosManager = class {
   }
 };
 
+// src/utils/jsonSchemaDialect.ts
+var JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+var DEFINITIONS_REF_PREFIX = "#/definitions/";
+function isPlainObject3(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function convertNode(node) {
+  if (Array.isArray(node)) return node.map(convertNode);
+  if (!isPlainObject3(node)) return node;
+  const hasTupleItems = Array.isArray(node.items);
+  const out = {};
+  for (const [key, value] of Object.entries(node)) {
+    switch (key) {
+      case "$schema":
+        break;
+      case "definitions":
+        out.$defs = convertNode(value);
+        break;
+      case "$ref":
+        out.$ref = typeof value === "string" && value.startsWith(DEFINITIONS_REF_PREFIX) ? "#/$defs/" + value.slice(DEFINITIONS_REF_PREFIX.length) : value;
+        break;
+      case "items":
+        if (hasTupleItems) out.prefixItems = value.map(convertNode);
+        else out.items = convertNode(value);
+        break;
+      case "additionalItems":
+        if (hasTupleItems) out.items = convertNode(value);
+        break;
+      case "dependencies": {
+        const dependentRequired = {};
+        const dependentSchemas = {};
+        if (isPlainObject3(value)) {
+          for (const [property, dependency] of Object.entries(value)) {
+            if (Array.isArray(dependency)) dependentRequired[property] = dependency;
+            else dependentSchemas[property] = convertNode(dependency);
+          }
+        }
+        if (Object.keys(dependentRequired).length > 0) out.dependentRequired = dependentRequired;
+        if (Object.keys(dependentSchemas).length > 0) out.dependentSchemas = dependentSchemas;
+        break;
+      }
+      case "exclusiveMinimum":
+      case "exclusiveMaximum": {
+        const bound = key === "exclusiveMinimum" ? node.minimum : node.maximum;
+        if (value === true && typeof bound === "number") out[key] = bound;
+        else if (value !== false) out[key] = convertNode(value);
+        break;
+      }
+      case "minimum":
+        if (node.exclusiveMinimum === true) break;
+        out.minimum = convertNode(value);
+        break;
+      case "maximum":
+        if (node.exclusiveMaximum === true) break;
+        out.maximum = convertNode(value);
+        break;
+      default:
+        out[key] = convertNode(value);
+    }
+  }
+  return out;
+}
+function toJsonSchema2020_12(schema) {
+  if (!isPlainObject3(schema)) return schema;
+  return {
+    $schema: JSON_SCHEMA_2020_12,
+    ...convertNode(schema)
+  };
+}
+function normalizeOutgoingMessage(message) {
+  if (!isPlainObject3(message)) return message;
+  const result = message.result;
+  if (!isPlainObject3(result) || !Array.isArray(result.tools)) return message;
+  const tools = result.tools.map((tool) => {
+    if (!isPlainObject3(tool)) return tool;
+    const next = { ...tool };
+    if (isPlainObject3(tool.inputSchema)) next.inputSchema = toJsonSchema2020_12(tool.inputSchema);
+    if (isPlainObject3(tool.outputSchema))
+      next.outputSchema = toJsonSchema2020_12(tool.outputSchema);
+    return next;
+  });
+  return { ...message, result: { ...result, tools } };
+}
+function withJsonSchema2020_12(transport) {
+  const originalSend = transport.send.bind(transport);
+  transport.send = (message, options) => originalSend(normalizeOutgoingMessage(message), options);
+  return transport;
+}
+
 // src/tools/respond.ts
 function successResponse(message, structured) {
   const res = { content: [{ type: "text", text: message }] };
@@ -23855,7 +23944,7 @@ async function main() {
   process.on("SIGINT", () => shutdown("SIGINT"));
   process.stdin.on("end", () => shutdown("stdin EOF"));
   process.stdin.on("close", () => shutdown("stdin close"));
-  const transport = new StdioServerTransport();
+  const transport = withJsonSchema2020_12(new StdioServerTransport());
   await server.connect(transport);
   console.error(`apple-photos-mcp v${version2} running on stdio`);
 }

--- a/build/index.js
+++ b/build/index.js
@@ -22725,8 +22725,28 @@ var PhotosManager = class {
 // src/utils/jsonSchemaDialect.ts
 var JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema";
 var DEFINITIONS_REF_PREFIX = "#/definitions/";
+var SCHEMA_MAP_KEYWORDS = /* @__PURE__ */ new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "dependentSchemas"
+]);
+var DATA_KEYWORDS = /* @__PURE__ */ new Set([
+  "enum",
+  "const",
+  "default",
+  "examples",
+  "required",
+  "dependentRequired"
+]);
 function isPlainObject3(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function convertSchemaMap(node) {
+  if (!isPlainObject3(node)) return node;
+  const out = {};
+  for (const [name, subschema] of Object.entries(node)) out[name] = convertNode(subschema);
+  return out;
 }
 function convertNode(node) {
   if (Array.isArray(node)) return node.map(convertNode);
@@ -22738,7 +22758,7 @@ function convertNode(node) {
       case "$schema":
         break;
       case "definitions":
-        out.$defs = convertNode(value);
+        out.$defs = convertSchemaMap(value);
         break;
       case "$ref":
         out.$ref = typeof value === "string" && value.startsWith(DEFINITIONS_REF_PREFIX) ? "#/$defs/" + value.slice(DEFINITIONS_REF_PREFIX.length) : value;
@@ -22779,7 +22799,9 @@ function convertNode(node) {
         out.maximum = convertNode(value);
         break;
       default:
-        out[key] = convertNode(value);
+        if (DATA_KEYWORDS.has(key)) out[key] = value;
+        else if (SCHEMA_MAP_KEYWORDS.has(key)) out[key] = convertSchemaMap(value);
+        else out[key] = convertNode(value);
     }
   }
   return out;

--- a/codex/.codex-plugin/plugin.json
+++ b/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "Query and export from the macOS Apple Photos library via osxphotos - search by date/album/keyword/person, list albums and folders, fetch metadata, export originals or edited photos, and (opt-in via APPLE_PHOTOS_MCP_ENABLE_WRITES=1) organize albums and set titles/keywords/favorites (macOS only).",
   "author": {
     "name": "Rob Sweet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-photos-mcp",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "packageManager": "pnpm@11.9.0",
   "description": "MCP server for Apple Photos - query, search, export, and inspect the macOS Photos library via Claude and other AI assistants, plus opt-in album/metadata write tools (read-only by default)",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { PhotosManager } from "./services/photosManager.js";
 import { killActiveSidecars } from "./utils/python.js";
+import { withJsonSchema2020_12 } from "./utils/jsonSchemaDialect.js";
 import type { SidecarProgress } from "./utils/sidecarClient.js";
 import { imageResponse, successResponse, withErrorHandling } from "./tools/respond.js";
 import { runDoctor, formatDoctorReport } from "./tools/doctor.js";
@@ -1283,7 +1284,7 @@ async function main() {
   process.stdin.on("end", () => shutdown("stdin EOF"));
   process.stdin.on("close", () => shutdown("stdin close"));
 
-  const transport = new StdioServerTransport();
+  const transport = withJsonSchema2020_12(new StdioServerTransport());
   await server.connect(transport);
   console.error(`apple-photos-mcp v${version} running on stdio`);
 }

--- a/src/utils/jsonSchemaDialect.test.ts
+++ b/src/utils/jsonSchemaDialect.test.ts
@@ -331,7 +331,8 @@ describe("toJsonSchema2020_12 — position awareness (keys are data, not keyword
     // inside patternProperties/$defs are caller-chosen NAMES, not declarations —
     // so count dialect URIs, not the literal key.
     expect(out.$schema).toBe(JSON_SCHEMA_2020_12);
-    expect(JSON.stringify(out).match(/json-schema\.org/g)).toHaveLength(1);
+    const dialectDeclarations = JSON.stringify(out).split(JSON_SCHEMA_2020_12).length - 1;
+    expect(dialectDeclarations).toBe(1);
     expect(JSON.stringify(out)).not.toContain("draft-07");
   });
 

--- a/src/utils/jsonSchemaDialect.test.ts
+++ b/src/utils/jsonSchemaDialect.test.ts
@@ -171,6 +171,205 @@ describe("toJsonSchema2020_12", () => {
   });
 });
 
+/**
+ * Position awareness: a "properties" map's keys are caller-chosen TOOL PARAMETER
+ * NAMES, not schema keywords. Rewriting them corrupts the schema — a parameter
+ * named "$schema" used to be silently deleted while "required" still listed it,
+ * producing a schema no input could satisfy. Likewise "enum"/"const"/"default"
+ * hold instance DATA, so recursing into them rewrote a caller's literal values.
+ */
+describe("toJsonSchema2020_12 — position awareness (keys are data, not keywords)", () => {
+  it("keeps a tool parameter NAMED definitions (does not rename it to $defs) and still converts its subschema", () => {
+    const out = toJsonSchema2020_12({
+      type: "object",
+      properties: {
+        definitions: {
+          $schema: DRAFT_07,
+          type: "object",
+          description: "a caller's parameter that happens to be named definitions",
+        },
+      },
+      required: ["definitions"],
+    }) as any;
+
+    // The parameter name survives verbatim at its own position…
+    expect(Object.keys(out.properties)).toEqual(["definitions"]);
+    expect(out.properties.$defs).toBeUndefined();
+    // …and no stray $defs was hoisted anywhere.
+    expect(out.$defs).toBeUndefined();
+    // Recursion still happens INSIDE the value: the nested draft-07 $schema is gone.
+    expect(out.properties.definitions).toEqual({
+      type: "object",
+      description: "a caller's parameter that happens to be named definitions",
+    });
+    expect(JSON.stringify(out)).not.toContain("draft-07");
+    // required still names something that exists.
+    expect(out.required).toEqual(["definitions"]);
+    expect(out.properties[out.required[0]]).toBeDefined();
+  });
+
+  it("PRESERVES a tool parameter named $schema, keeping the schema satisfiable", () => {
+    const out = toJsonSchema2020_12({
+      type: "object",
+      properties: {
+        $schema: { type: "string", description: "the dialect URI to validate against" },
+        name: { type: "string" },
+      },
+      required: ["$schema"],
+    }) as any;
+
+    expect(out.properties.$schema).toEqual({
+      type: "string",
+      description: "the dialect URI to validate against",
+    });
+    expect(out.required).toEqual(["$schema"]);
+    // The required name resolves to a real property — the schema is satisfiable.
+    expect(out.properties[out.required[0]]).toBeDefined();
+    // Exactly one $schema is a dialect declaration: the root one.
+    expect(out.$schema).toBe(JSON_SCHEMA_2020_12);
+  });
+
+  it("keeps tool parameters named dependencies and additionalItems intact (name and value)", () => {
+    const out = toJsonSchema2020_12({
+      type: "object",
+      properties: {
+        dependencies: { type: "array", items: { type: "string" } },
+        additionalItems: { type: "boolean", description: "allow extras" },
+      },
+      required: ["dependencies", "additionalItems"],
+    }) as any;
+
+    expect(Object.keys(out.properties).sort()).toEqual(["additionalItems", "dependencies"]);
+    expect(out.properties.dependencies).toEqual({ type: "array", items: { type: "string" } });
+    expect(out.properties.additionalItems).toEqual({
+      type: "boolean",
+      description: "allow extras",
+    });
+    // No keyword restructuring leaked out of the properties map.
+    expect(out.dependentRequired).toBeUndefined();
+    expect(out.dependentSchemas).toBeUndefined();
+    expect(out.properties.dependentRequired).toBeUndefined();
+    expect(out.properties.dependentSchemas).toBeUndefined();
+    expect(out.required).toEqual(["dependencies", "additionalItems"]);
+  });
+
+  it("still renames a REAL definitions block at a schema position and rewrites its $ref", () => {
+    const out = toJsonSchema2020_12({
+      type: "object",
+      definitions: { Photo: { $schema: DRAFT_07, type: "string" } },
+      properties: {
+        photo: { $ref: "#/definitions/Photo" },
+        definitions: { type: "number" },
+      },
+    }) as any;
+
+    // Keyword position: renamed, and its VALUES converted (nested $schema stripped).
+    expect(out.$defs).toEqual({ Photo: { type: "string" } });
+    expect(out.definitions).toBeUndefined();
+    expect(out.properties.photo.$ref).toBe("#/$defs/Photo");
+    // Data position: untouched, in the same document.
+    expect(out.properties.definitions).toEqual({ type: "number" });
+  });
+
+  it("passes enum/const/default values through verbatim even when they collide with keyword names", () => {
+    const out = toJsonSchema2020_12({
+      type: "object",
+      properties: {
+        mode: {
+          type: "string",
+          enum: ["definitions", "$schema", "additionalItems"],
+          default: { definitions: 1, $schema: "x", dependencies: { a: ["b"] } },
+        },
+        pinned: {
+          const: { $schema: DRAFT_07, definitions: { Nested: { items: [1, 2] } } },
+        },
+        sampled: {
+          examples: [{ $schema: "keep me", additionalItems: true }],
+        },
+      },
+    }) as any;
+
+    expect(out.properties.mode.enum).toEqual(["definitions", "$schema", "additionalItems"]);
+    expect(out.properties.mode.default).toEqual({
+      definitions: 1,
+      $schema: "x",
+      dependencies: { a: ["b"] },
+    });
+    // Literal data is NOT a schema: the draft-07 string inside const survives.
+    expect(out.properties.pinned.const).toEqual({
+      $schema: DRAFT_07,
+      definitions: { Nested: { items: [1, 2] } },
+    });
+    expect(out.properties.pinned.const.$defs).toBeUndefined();
+    expect(out.properties.sampled.examples).toEqual([
+      { $schema: "keep me", additionalItems: true },
+    ]);
+  });
+
+  it("leaves patternProperties and $defs map KEYS untouched while converting their VALUES", () => {
+    const out = toJsonSchema2020_12({
+      type: "object",
+      patternProperties: {
+        "^\\$schema$": { $schema: DRAFT_07, type: "string" },
+        "^definitions$": { $schema: DRAFT_07, type: "number" },
+      },
+      $defs: {
+        definitions: { $schema: DRAFT_07, type: "boolean" },
+        $schema: { $schema: DRAFT_07, type: "null" },
+      },
+    }) as any;
+
+    expect(Object.keys(out.patternProperties)).toEqual(["^\\$schema$", "^definitions$"]);
+    expect(out.patternProperties["^\\$schema$"]).toEqual({ type: "string" });
+    expect(out.patternProperties["^definitions$"]).toEqual({ type: "number" });
+
+    expect(Object.keys(out.$defs).sort()).toEqual(["$schema", "definitions"]);
+    expect(out.$defs.definitions).toEqual({ type: "boolean" });
+    expect(out.$defs.$schema).toEqual({ type: "null" });
+
+    // The root is the ONLY dialect declaration. The surviving "$schema" spellings
+    // inside patternProperties/$defs are caller-chosen NAMES, not declarations —
+    // so count dialect URIs, not the literal key.
+    expect(out.$schema).toBe(JSON_SCHEMA_2020_12);
+    expect(JSON.stringify(out).match(/json-schema\.org/g)).toHaveLength(1);
+    expect(JSON.stringify(out)).not.toContain("draft-07");
+  });
+
+  it("round-trips a real-world outputSchema (apple-notes-mcp get-checklist-state) unchanged apart from the root dialect", () => {
+    // properties.items is a caller-chosen parameter name that also happens to be
+    // a schema keyword — the exact shape shipping on the fleet today.
+    const shipped = {
+      type: "object",
+      properties: {
+        noteId: { type: "string" },
+        items: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              text: { type: "string" },
+              checked: { type: "boolean" },
+              index: { type: "number" },
+            },
+            required: ["text", "checked", "index"],
+            additionalProperties: false,
+          },
+        },
+        total: { type: "number" },
+        checkedCount: { type: "number" },
+      },
+      required: ["noteId", "items"],
+      additionalProperties: false,
+    };
+    const out = toJsonSchema2020_12({ $schema: DRAFT_07, ...shipped }) as any;
+
+    const { $schema, ...body } = out;
+    expect($schema).toBe(JSON_SCHEMA_2020_12);
+    expect(body).toEqual(shipped);
+    expect(JSON.stringify(out)).not.toContain("draft-07");
+  });
+});
+
 describe("normalizeOutgoingMessage", () => {
   const toolsListResult = () => ({
     jsonrpc: "2.0" as const,

--- a/src/utils/jsonSchemaDialect.test.ts
+++ b/src/utils/jsonSchemaDialect.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Unit tests for the JSON Schema dialect normalizer that rewrites outgoing MCP
+ * tool schemas from the SDK's draft-07 output to JSON Schema 2020-12.
+ *
+ * The converter is a no-op on today's schemas — zod-to-json-schema emits nothing
+ * but the dialect declaration that changed — so the keyword-rewrite cases below
+ * are the guard that keeps it correct if a new zod construct ever introduces
+ * one. See src/utils/jsonSchemaDialect.ts for the root cause.
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  JSON_SCHEMA_2020_12,
+  normalizeOutgoingMessage,
+  toJsonSchema2020_12,
+  withJsonSchema2020_12,
+} from "./jsonSchemaDialect.js";
+
+const DRAFT_07 = "http://json-schema.org/draft-07/schema#";
+
+describe("toJsonSchema2020_12", () => {
+  it("declares the 2020-12 dialect at the root", () => {
+    const out = toJsonSchema2020_12({ type: "object", properties: {} }) as Record<string, unknown>;
+    expect(out.$schema).toBe(JSON_SCHEMA_2020_12);
+    expect(out.$schema).toBe("https://json-schema.org/draft/2020-12/schema");
+  });
+
+  it("replaces a draft-07 root declaration rather than keeping both", () => {
+    const out = toJsonSchema2020_12({ $schema: DRAFT_07, type: "object" }) as Record<
+      string,
+      unknown
+    >;
+    expect(out.$schema).toBe(JSON_SCHEMA_2020_12);
+    expect(JSON.stringify(out)).not.toContain("draft-07");
+  });
+
+  it("strips $schema from nested subschemas — only the root declares a dialect", () => {
+    const out = toJsonSchema2020_12({
+      type: "object",
+      properties: {
+        nested: { $schema: DRAFT_07, type: "string" },
+        list: { type: "array", items: { $schema: DRAFT_07, type: "number" } },
+      },
+    }) as any;
+
+    expect(out.$schema).toBe(JSON_SCHEMA_2020_12);
+    expect(out.properties.nested).toEqual({ type: "string" });
+    expect(out.properties.list.items).toEqual({ type: "number" });
+    expect(JSON.stringify(out).match(/\$schema/g)).toHaveLength(1);
+  });
+
+  it("renames definitions to $defs and rewrites #/definitions/ refs to #/$defs/", () => {
+    const out = toJsonSchema2020_12({
+      type: "object",
+      definitions: { Photo: { type: "string" } },
+      properties: { photo: { $ref: "#/definitions/Photo" } },
+    }) as any;
+
+    expect(out.$defs).toEqual({ Photo: { type: "string" } });
+    expect(out.definitions).toBeUndefined();
+    expect(out.properties.photo.$ref).toBe("#/$defs/Photo");
+  });
+
+  it("leaves a non-definitions $ref (e.g. a sibling property pointer) untouched", () => {
+    const out = toJsonSchema2020_12({
+      type: "object",
+      properties: {
+        dateFrom: { type: "string" },
+        dateTo: { $ref: "#/properties/dateFrom" },
+      },
+    }) as any;
+
+    expect(out.properties.dateTo.$ref).toBe("#/properties/dateFrom");
+  });
+
+  it("converts tuple items to prefixItems and a sibling additionalItems to items", () => {
+    const out = toJsonSchema2020_12({
+      type: "array",
+      items: [{ type: "string" }, { type: "number" }],
+      additionalItems: { type: "boolean" },
+    }) as any;
+
+    expect(out.prefixItems).toEqual([{ type: "string" }, { type: "number" }]);
+    expect(out.items).toEqual({ type: "boolean" });
+    expect(out.additionalItems).toBeUndefined();
+  });
+
+  it("drops a stray additionalItems when items is NOT a tuple, rather than clobbering items", () => {
+    const out = toJsonSchema2020_12({
+      type: "array",
+      items: { type: "string" },
+      additionalItems: { type: "boolean" },
+    }) as any;
+
+    expect(out.items).toEqual({ type: "string" });
+    expect(out.additionalItems).toBeUndefined();
+    expect(out.prefixItems).toBeUndefined();
+  });
+
+  it("splits dependencies into dependentRequired (arrays) and dependentSchemas (objects)", () => {
+    const out = toJsonSchema2020_12({
+      type: "object",
+      dependencies: {
+        creditCard: ["billingAddress"],
+        shipped: { properties: { trackingNumber: { type: "string" } } },
+      },
+    }) as any;
+
+    expect(out.dependencies).toBeUndefined();
+    expect(out.dependentRequired).toEqual({ creditCard: ["billingAddress"] });
+    expect(out.dependentSchemas).toEqual({
+      shipped: { properties: { trackingNumber: { type: "string" } } },
+    });
+  });
+
+  it("collapses boolean exclusiveMinimum:true + minimum into a numeric exclusiveMinimum", () => {
+    const out = toJsonSchema2020_12({
+      type: "number",
+      minimum: 5,
+      exclusiveMinimum: true,
+    }) as any;
+
+    expect(out.exclusiveMinimum).toBe(5);
+    expect(out.minimum).toBeUndefined();
+  });
+
+  it("drops exclusiveMinimum:false and keeps minimum", () => {
+    const out = toJsonSchema2020_12({
+      type: "number",
+      minimum: 5,
+      exclusiveMinimum: false,
+    }) as any;
+
+    expect(out.minimum).toBe(5);
+    expect(out.exclusiveMinimum).toBeUndefined();
+  });
+
+  it("collapses boolean exclusiveMaximum:true + maximum, and drops exclusiveMaximum:false", () => {
+    const collapsed = toJsonSchema2020_12({
+      type: "number",
+      maximum: 10,
+      exclusiveMaximum: true,
+    }) as any;
+    expect(collapsed.exclusiveMaximum).toBe(10);
+    expect(collapsed.maximum).toBeUndefined();
+
+    const kept = toJsonSchema2020_12({
+      type: "number",
+      maximum: 10,
+      exclusiveMaximum: false,
+    }) as any;
+    expect(kept.maximum).toBe(10);
+    expect(kept.exclusiveMaximum).toBeUndefined();
+  });
+
+  it("passes an already-numeric exclusiveMinimum/Maximum through unchanged", () => {
+    const out = toJsonSchema2020_12({
+      type: "number",
+      exclusiveMinimum: 1,
+      exclusiveMaximum: 9,
+    }) as any;
+
+    expect(out.exclusiveMinimum).toBe(1);
+    expect(out.exclusiveMaximum).toBe(9);
+  });
+
+  it("returns non-object schemas (booleans, null) untouched", () => {
+    expect(toJsonSchema2020_12(true)).toBe(true);
+    expect(toJsonSchema2020_12(false)).toBe(false);
+    expect(toJsonSchema2020_12(null)).toBe(null);
+  });
+});
+
+describe("normalizeOutgoingMessage", () => {
+  const toolsListResult = () => ({
+    jsonrpc: "2.0" as const,
+    id: 2,
+    result: {
+      tools: [
+        {
+          name: "query",
+          inputSchema: { $schema: DRAFT_07, type: "object", properties: {} },
+          outputSchema: { $schema: DRAFT_07, type: "object", properties: {} },
+        },
+        {
+          name: "health-check",
+          inputSchema: { $schema: DRAFT_07, type: "object", properties: {} },
+        },
+      ],
+    },
+  });
+
+  it("rewrites inputSchema and outputSchema on every tool in a tools/list result", () => {
+    const out = normalizeOutgoingMessage(toolsListResult()) as any;
+
+    expect(out.result.tools).toHaveLength(2);
+    for (const tool of out.result.tools) {
+      expect(tool.inputSchema.$schema).toBe(JSON_SCHEMA_2020_12);
+    }
+    expect(out.result.tools[0].outputSchema.$schema).toBe(JSON_SCHEMA_2020_12);
+    expect(JSON.stringify(out)).not.toContain("draft-07");
+  });
+
+  it("leaves a tool without an outputSchema alone (does not invent one)", () => {
+    const out = normalizeOutgoingMessage(toolsListResult()) as any;
+
+    expect(out.result.tools[1].name).toBe("health-check");
+    expect("outputSchema" in out.result.tools[1]).toBe(false);
+  });
+
+  it("preserves every other field on the message and on each tool", () => {
+    const message = {
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        nextCursor: "abc",
+        tools: [
+          {
+            name: "query",
+            title: "Query photos",
+            description: "…",
+            annotations: { readOnlyHint: true },
+            inputSchema: { type: "object" },
+          },
+        ],
+      },
+    };
+    const out = normalizeOutgoingMessage(message) as any;
+
+    expect(out.jsonrpc).toBe("2.0");
+    expect(out.id).toBe(2);
+    expect(out.result.nextCursor).toBe("abc");
+    expect(out.result.tools[0]).toMatchObject({
+      name: "query",
+      title: "Query photos",
+      description: "…",
+      annotations: { readOnlyHint: true },
+    });
+  });
+
+  it("returns a tools/call result byte-identical", () => {
+    const message = {
+      jsonrpc: "2.0",
+      id: 3,
+      result: { content: [{ type: "text", text: "ok" }], structuredContent: { healthy: true } },
+    };
+    const out = normalizeOutgoingMessage(message);
+
+    expect(out).toBe(message);
+    expect(JSON.stringify(out)).toBe(JSON.stringify(message));
+  });
+
+  it("returns a notification byte-identical", () => {
+    const message = {
+      jsonrpc: "2.0",
+      method: "notifications/progress",
+      params: { progressToken: 1, progress: 3, total: 10 },
+    };
+    const out = normalizeOutgoingMessage(message);
+
+    expect(out).toBe(message);
+    expect(JSON.stringify(out)).toBe(JSON.stringify(message));
+  });
+
+  it("returns an error response and non-object inputs unchanged", () => {
+    const error = { jsonrpc: "2.0", id: 4, error: { code: -32601, message: "Method not found" } };
+    expect(normalizeOutgoingMessage(error)).toBe(error);
+    expect(normalizeOutgoingMessage(null)).toBe(null);
+    expect(normalizeOutgoingMessage("not a message")).toBe("not a message");
+  });
+});
+
+describe("withJsonSchema2020_12", () => {
+  it("returns the same transport instance", () => {
+    const transport = { send: vi.fn(async () => {}) } as unknown as Transport;
+    expect(withJsonSchema2020_12(transport)).toBe(transport);
+  });
+
+  it("delegates to the original send with the NORMALIZED message, forwarding options", async () => {
+    const sent: Array<{ message: unknown; options: unknown }> = [];
+    const originalSend = vi.fn(async (message: unknown, options?: unknown) => {
+      sent.push({ message, options });
+    });
+    const transport = { send: originalSend } as unknown as Transport;
+
+    withJsonSchema2020_12(transport);
+
+    await transport.send(
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        result: {
+          tools: [
+            {
+              name: "query",
+              inputSchema: { $schema: DRAFT_07, type: "object" },
+              outputSchema: { $schema: DRAFT_07, type: "object" },
+            },
+          ],
+        },
+      } as any,
+      { relatedRequestId: 7 }
+    );
+
+    expect(originalSend).toHaveBeenCalledTimes(1);
+    const delivered = sent[0].message as any;
+    expect(delivered.result.tools[0].inputSchema.$schema).toBe(JSON_SCHEMA_2020_12);
+    expect(delivered.result.tools[0].outputSchema.$schema).toBe(JSON_SCHEMA_2020_12);
+    expect(JSON.stringify(delivered)).not.toContain("draft-07");
+    expect(sent[0].options).toEqual({ relatedRequestId: 7 });
+  });
+
+  it("passes a non-tools/list message straight through to the original send", async () => {
+    const originalSend = vi.fn(async () => {});
+    const transport = { send: originalSend } as unknown as Transport;
+    const message = { jsonrpc: "2.0", method: "notifications/initialized" };
+
+    withJsonSchema2020_12(transport);
+    await transport.send(message as any);
+
+    expect(originalSend).toHaveBeenCalledWith(message, undefined);
+    expect(originalSend.mock.calls[0][0]).toBe(message);
+  });
+
+  it("keeps the original send bound to its transport (no lost `this`)", async () => {
+    class FakeTransport {
+      sentFrom: unknown = null;
+      async send(message: unknown) {
+        // Would throw on an unbound call.
+        this.sentFrom = message;
+      }
+    }
+    const transport = new FakeTransport() as unknown as Transport;
+    withJsonSchema2020_12(transport);
+
+    await transport.send({ jsonrpc: "2.0", method: "ping" } as any);
+    expect((transport as unknown as FakeTransport).sentFrom).toEqual({
+      jsonrpc: "2.0",
+      method: "ping",
+    });
+  });
+});

--- a/src/utils/jsonSchemaDialect.ts
+++ b/src/utils/jsonSchemaDialect.ts
@@ -1,0 +1,154 @@
+/**
+ * JSON Schema dialect normalization for outgoing MCP tool schemas.
+ *
+ * The MCP SDK converts our Zod tool schemas with a draft-07 target and stamps
+ * "$schema": "http://json-schema.org/draft-07/schema#" onto every emitted
+ * inputSchema/outputSchema. MCP has since standardized on JSON Schema 2020-12
+ * (SEP-834 / SEP-1613 / SEP-2106), and clients now reject anything else:
+ *
+ *   Tool '<name>' has an invalid outputSchema: JSON Schema declares an
+ *   unsupported dialect ("$schema": "http://json-schema.org/draft-07/schema#").
+ *   The default validator supports JSON Schema 2020-12 only.
+ *
+ * Upgrading Zod does NOT help: the SDK calls its converter without a target, so
+ * both its v3 (zod-to-json-schema) and v4 (zod/v4-mini toJSONSchema) branches
+ * fall back to draft-07. Verified empirically against SDK 1.30.0 + Zod 4.4.3.
+ *
+ * So we normalize the outgoing payload ourselves at the transport boundary --
+ * the only public seam that does not reach into SDK internals.
+ */
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+
+export const JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+
+const DEFINITIONS_REF_PREFIX = "#/definitions/";
+
+type JsonObject = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Recursively rewrite the draft-07 keywords whose meaning or spelling changed
+ * in 2020-12. Anything already dialect-neutral passes through untouched.
+ */
+function convertNode(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(convertNode);
+  if (!isPlainObject(node)) return node;
+
+  const hasTupleItems = Array.isArray(node.items);
+  const out: JsonObject = {};
+
+  for (const [key, value] of Object.entries(node)) {
+    switch (key) {
+      case "$schema":
+        // Dropped here and re-stamped at the root only; subschemas must not
+        // carry their own dialect declaration.
+        break;
+
+      case "definitions":
+        out.$defs = convertNode(value);
+        break;
+
+      case "$ref":
+        out.$ref =
+          typeof value === "string" && value.startsWith(DEFINITIONS_REF_PREFIX)
+            ? "#/$defs/" + value.slice(DEFINITIONS_REF_PREFIX.length)
+            : value;
+        break;
+
+      case "items":
+        // The tuple form "items: [A, B]" became "prefixItems" in 2020-12.
+        if (hasTupleItems) out.prefixItems = (value as unknown[]).map(convertNode);
+        else out.items = convertNode(value);
+        break;
+
+      case "additionalItems":
+        // Only meaningful alongside a tuple, where it is now plain "items".
+        if (hasTupleItems) out.items = convertNode(value);
+        break;
+
+      case "dependencies": {
+        // Split into the two keywords that replaced it.
+        const dependentRequired: JsonObject = {};
+        const dependentSchemas: JsonObject = {};
+        if (isPlainObject(value)) {
+          for (const [property, dependency] of Object.entries(value)) {
+            if (Array.isArray(dependency)) dependentRequired[property] = dependency;
+            else dependentSchemas[property] = convertNode(dependency);
+          }
+        }
+        if (Object.keys(dependentRequired).length > 0) out.dependentRequired = dependentRequired;
+        if (Object.keys(dependentSchemas).length > 0) out.dependentSchemas = dependentSchemas;
+        break;
+      }
+
+      case "exclusiveMinimum":
+      case "exclusiveMaximum": {
+        // Draft-4 spelled these as booleans modifying minimum/maximum.
+        const bound = key === "exclusiveMinimum" ? node.minimum : node.maximum;
+        if (value === true && typeof bound === "number") out[key] = bound;
+        else if (value !== false) out[key] = convertNode(value);
+        break;
+      }
+
+      case "minimum":
+        if (node.exclusiveMinimum === true) break;
+        out.minimum = convertNode(value);
+        break;
+
+      case "maximum":
+        if (node.exclusiveMaximum === true) break;
+        out.maximum = convertNode(value);
+        break;
+
+      default:
+        out[key] = convertNode(value);
+    }
+  }
+
+  return out;
+}
+
+/** Convert one JSON Schema document to 2020-12, declaring the dialect at its root. */
+export function toJsonSchema2020_12<T>(schema: T): T {
+  if (!isPlainObject(schema)) return schema;
+  return {
+    $schema: JSON_SCHEMA_2020_12,
+    ...(convertNode(schema) as JsonObject),
+  } as T;
+}
+
+/**
+ * Rewrite the tool schemas in an outgoing tools/list result. Any other message
+ * -- responses, notifications, errors -- is returned unchanged.
+ */
+export function normalizeOutgoingMessage(message: unknown): unknown {
+  if (!isPlainObject(message)) return message;
+
+  const result = message.result;
+  if (!isPlainObject(result) || !Array.isArray(result.tools)) return message;
+
+  const tools = result.tools.map((tool) => {
+    if (!isPlainObject(tool)) return tool;
+    const next: JsonObject = { ...tool };
+    if (isPlainObject(tool.inputSchema)) next.inputSchema = toJsonSchema2020_12(tool.inputSchema);
+    if (isPlainObject(tool.outputSchema))
+      next.outputSchema = toJsonSchema2020_12(tool.outputSchema);
+    return next;
+  });
+
+  return { ...message, result: { ...result, tools } };
+}
+
+/**
+ * Wrap a transport so every tools/list payload it sends declares 2020-12.
+ * Returns the same instance, so it composes directly into server.connect().
+ */
+export function withJsonSchema2020_12<T extends Transport>(transport: T): T {
+  const originalSend = transport.send.bind(transport);
+  transport.send = (message, options) =>
+    originalSend(normalizeOutgoingMessage(message) as Parameters<Transport["send"]>[0], options);
+  return transport;
+}

--- a/src/utils/jsonSchemaDialect.ts
+++ b/src/utils/jsonSchemaDialect.ts
@@ -23,10 +23,51 @@ export const JSON_SCHEMA_2020_12 = "https://json-schema.org/draft/2020-12/schema
 
 const DEFINITIONS_REF_PREFIX = "#/definitions/";
 
+/**
+ * Keywords whose value is a map of caller-chosen NAME -> schema.
+ *
+ * Their keys are user data — a tool is free to declare a parameter literally
+ * named "definitions", "$schema", "dependencies" or "additionalItems" — so the
+ * keys must never be run through the keyword rewrites below. Only the VALUES
+ * are schemas, and only they get converted.
+ *
+ * ("definitions" is deliberately absent: at a schema position it IS a keyword,
+ * and its own case in convertNode converts it and renames it to $defs.)
+ */
+const SCHEMA_MAP_KEYWORDS: ReadonlySet<string> = new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "dependentSchemas",
+]);
+
+/**
+ * Keywords whose value is instance DATA rather than a schema. Recursing into
+ * them would rewrite a caller's literal values as if they were schema keywords
+ * — e.g. `default: { definitions: 1, $schema: "x" }` would lose "$schema" and
+ * see "definitions" renamed to "$defs".
+ */
+const DATA_KEYWORDS: ReadonlySet<string> = new Set([
+  "enum",
+  "const",
+  "default",
+  "examples",
+  "required",
+  "dependentRequired",
+]);
+
 type JsonObject = Record<string, unknown>;
 
 function isPlainObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Convert every VALUE of a name -> schema map, leaving the caller's names untouched. */
+function convertSchemaMap(node: unknown): unknown {
+  if (!isPlainObject(node)) return node;
+  const out: JsonObject = {};
+  for (const [name, subschema] of Object.entries(node)) out[name] = convertNode(subschema);
+  return out;
 }
 
 /**
@@ -48,10 +89,17 @@ function convertNode(node: unknown): unknown {
         break;
 
       case "definitions":
-        out.$defs = convertNode(value);
+        // A name -> schema map: rename the keyword, keep the caller's names.
+        out.$defs = convertSchemaMap(value);
         break;
 
       case "$ref":
+        // Known, deliberate limitation: only a $ref with the exact ROOT prefix
+        // "#/definitions/" is rewritten. A pointer THROUGH a nested definitions
+        // block (e.g. "#/properties/x/definitions/Y") is left alone, because
+        // "#/properties/definitions/..." could legitimately address a property
+        // NAMED definitions and the two are indistinguishable without resolving
+        // the pointer. The SDK's converter emits neither construct.
         out.$ref =
           typeof value === "string" && value.startsWith(DEFINITIONS_REF_PREFIX)
             ? "#/$defs/" + value.slice(DEFINITIONS_REF_PREFIX.length)
@@ -104,7 +152,12 @@ function convertNode(node: unknown): unknown {
         break;
 
       default:
-        out[key] = convertNode(value);
+        // Position-aware: instance data passes through verbatim, name -> schema
+        // maps get only their values converted, and everything else is a schema
+        // position and recurses normally.
+        if (DATA_KEYWORDS.has(key)) out[key] = value;
+        else if (SCHEMA_MAP_KEYWORDS.has(key)) out[key] = convertSchemaMap(value);
+        else out[key] = convertNode(value);
     }
   }
 

--- a/test/output-schema.test.ts
+++ b/test/output-schema.test.ts
@@ -12,6 +12,10 @@
  *      structuredContent is missing or fails the schema, which rejects callTool —
  *      so a resolving call proves a real payload validates against its schema.
  *      (Environment failures return isError results, which the SDK exempts.)
+ *   4. every advertised inputSchema/outputSchema declares JSON Schema 2020-12 and
+ *      carries no draft-07-only construct. The SDK emits draft-07 and clients now
+ *      reject that outright ("declares an unsupported dialect"), so this is the
+ *      end-to-end proof that the transport-level normalizer is wired in.
  *
  * Needs no Photos library, so it always runs (including CI). The Python sidecar
  * auto-bootstrap is disabled so the diagnostic round-trip stays fast and offline.
@@ -98,6 +102,87 @@ describe("outputSchema contract (real server over stdio)", () => {
         `additionalProperties:false, so any field they don't enumerate is rejected ` +
         `client-side and the whole result is lost: ${offenders.join(", ")}`
     ).toEqual([]);
+  });
+
+  it("every advertised schema declares JSON Schema 2020-12 (not draft-07)", async () => {
+    // Claude Desktop refuses a tool outright when its schema declares any other
+    // dialect: "Tool '<name>' has an invalid outputSchema: JSON Schema declares
+    // an unsupported dialect (\"$schema\": \"http://json-schema.org/draft-07/
+    // schema#\"). The default validator supports JSON Schema 2020-12 only."
+    // The MCP SDK calls its zod converter with no target, so BOTH its v3 and v4
+    // branches emit draft-07 — upgrading zod does not help. src/index.ts wraps
+    // the stdio transport in withJsonSchema2020_12() to rewrite the outgoing
+    // tools/list payload; this asserts that wrapper is actually in the path.
+    const { tools } = await client.listTools();
+    expect(tools.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const tool of tools) {
+      for (const key of ["inputSchema", "outputSchema"] as const) {
+        const schema = tool[key] as { $schema?: unknown } | undefined;
+        if (!schema) continue;
+        if (schema.$schema !== "https://json-schema.org/draft/2020-12/schema") {
+          offenders.push(`${tool.name}.${key}: ${JSON.stringify(schema.$schema)}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `every schema must declare https://json-schema.org/draft/2020-12/schema: ${offenders.join("; ")}`
+    ).toEqual([]);
+  });
+
+  it("no advertised schema contains a draft-07-only construct", async () => {
+    // The dialect declaration alone is not enough: a schema that says 2020-12
+    // while still using draft-07 spellings would validate differently (or not at
+    // all) under a 2020-12 validator. These are the keywords that changed.
+    const { tools } = await client.listTools();
+    const DRAFT_07_ONLY = ["definitions", "additionalItems", "dependencies"] as const;
+
+    const offenders: string[] = [];
+    for (const tool of tools) {
+      for (const key of ["inputSchema", "outputSchema"] as const) {
+        const schema = tool[key];
+        if (!schema) continue;
+        const serialized = JSON.stringify(schema);
+
+        if (serialized.includes("draft-07")) {
+          offenders.push(`${tool.name}.${key}: mentions draft-07`);
+        }
+        if (serialized.includes('"#/definitions/')) {
+          offenders.push(`${tool.name}.${key}: $ref points into #/definitions/ (now #/$defs/)`);
+        }
+        for (const keyword of DRAFT_07_ONLY) {
+          if (serialized.includes(`"${keyword}":`)) {
+            offenders.push(`${tool.name}.${key}: uses draft-07-only "${keyword}"`);
+          }
+        }
+
+        // A boolean exclusiveMinimum/Maximum is the draft-4 spelling; 2020-12
+        // requires a number.
+        const walk = (node: unknown, path: string): void => {
+          if (Array.isArray(node)) {
+            node.forEach((child, i) => walk(child, `${path}[${i}]`));
+            return;
+          }
+          if (typeof node !== "object" || node === null) return;
+          for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+            if ((k === "exclusiveMinimum" || k === "exclusiveMaximum") && typeof v === "boolean") {
+              offenders.push(`${tool.name}.${key}: boolean ${k} at ${path}`);
+            }
+            // Only the ROOT may declare a dialect.
+            if (k === "$schema" && path !== "") {
+              offenders.push(`${tool.name}.${key}: nested $schema at ${path}`);
+            }
+            walk(v, `${path}.${k}`);
+          }
+        };
+        walk(schema, "");
+      }
+    }
+    expect(offenders, `advertised schemas must be pure 2020-12: ${offenders.join("; ")}`).toEqual(
+      []
+    );
   });
 
   it("diagnostic tools' real output validates against their outputSchema (when reachable)", async () => {

--- a/test/output-schema.test.ts
+++ b/test/output-schema.test.ts
@@ -29,6 +29,34 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 
 const SERVER = resolve(__dirname, "../build/index.js");
 
+// Walk schema POSITIONS, not raw text. The keys of a `properties` map are
+// caller-chosen TOOL PARAMETER NAMES, not keywords, so a tool with a parameter
+// named `definitions` or `$schema` is perfectly legal and must not be reported;
+// and enum/const/default hold instance DATA, whose keys mean nothing here.
+// (Same distinction the normalizer itself makes — see src/utils/jsonSchemaDialect.ts.)
+const SCHEMA_MAP_KEYWORDS = ["properties", "patternProperties", "$defs", "dependentSchemas"];
+const DATA_KEYWORDS = ["enum", "const", "default", "examples", "required", "dependentRequired"];
+
+/** Re-enter only the subschema positions of `obj`, reporting each via `visit`. */
+function walkSubschemas(
+  obj: Record<string, unknown>,
+  path: string,
+  visit: (node: unknown, path: string) => void
+): void {
+  for (const [key, value] of Object.entries(obj)) {
+    if (DATA_KEYWORDS.includes(key)) continue;
+    if (SCHEMA_MAP_KEYWORDS.includes(key)) {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        for (const [name, sub] of Object.entries(value as Record<string, unknown>)) {
+          visit(sub, `${path}.${key}.${name}`);
+        }
+      }
+      continue;
+    }
+    visit(value, `${path}.${key}`);
+  }
+}
+
 describe("outputSchema contract (real server over stdio)", () => {
   let client: Client;
 
@@ -144,40 +172,46 @@ describe("outputSchema contract (real server over stdio)", () => {
       for (const key of ["inputSchema", "outputSchema"] as const) {
         const schema = tool[key];
         if (!schema) continue;
-        const serialized = JSON.stringify(schema);
-
-        if (serialized.includes("draft-07")) {
+        if (JSON.stringify(schema).includes("draft-07")) {
           offenders.push(`${tool.name}.${key}: mentions draft-07`);
         }
-        if (serialized.includes('"#/definitions/')) {
-          offenders.push(`${tool.name}.${key}: $ref points into #/definitions/ (now #/$defs/)`);
-        }
-        for (const keyword of DRAFT_07_ONLY) {
-          if (serialized.includes(`"${keyword}":`)) {
-            offenders.push(`${tool.name}.${key}: uses draft-07-only "${keyword}"`);
-          }
-        }
 
-        // A boolean exclusiveMinimum/Maximum is the draft-4 spelling; 2020-12
-        // requires a number.
         const walk = (node: unknown, path: string): void => {
           if (Array.isArray(node)) {
             node.forEach((child, i) => walk(child, `${path}[${i}]`));
             return;
           }
           if (typeof node !== "object" || node === null) return;
-          for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
-            if ((k === "exclusiveMinimum" || k === "exclusiveMaximum") && typeof v === "boolean") {
-              offenders.push(`${tool.name}.${key}: boolean ${k} at ${path}`);
+          const obj = node as Record<string, unknown>;
+
+          for (const keyword of DRAFT_07_ONLY) {
+            if (keyword in obj) {
+              offenders.push(
+                `${tool.name}.${key}: draft-07-only "${keyword}" at ${path || "root"}`
+              );
             }
-            // Only the ROOT may declare a dialect.
-            if (k === "$schema" && path !== "") {
-              offenders.push(`${tool.name}.${key}: nested $schema at ${path}`);
-            }
-            walk(v, `${path}.${k}`);
           }
+          if (Array.isArray(obj.items)) {
+            offenders.push(`${tool.name}.${key}: tuple-form "items" at ${path || "root"}`);
+          }
+          // A boolean exclusiveMinimum/Maximum is the draft-4 spelling; 2020-12
+          // requires a number.
+          for (const k of ["exclusiveMinimum", "exclusiveMaximum"] as const) {
+            if (typeof obj[k] === "boolean") {
+              offenders.push(`${tool.name}.${key}: boolean ${k} at ${path || "root"}`);
+            }
+          }
+          if (typeof obj.$ref === "string" && obj.$ref.startsWith("#/definitions/")) {
+            offenders.push(`${tool.name}.${key}: $ref into #/definitions/ (now #/$defs/)`);
+          }
+          // Only the ROOT may declare a dialect.
+          if (path !== "" && "$schema" in obj) {
+            offenders.push(`${tool.name}.${key}: nested $schema at ${path}`);
+          }
+
+          walkSubschemas(obj, path, walk);
         };
-        walk(schema, "");
+        walk(schema as Record<string, unknown>, "");
       }
     }
     expect(offenders, `advertised schemas must be pure 2020-12: ${offenders.join("; ")}`).toEqual(


### PR DESCRIPTION
## The symptom

Claude Desktop refuses **every** tool this server advertises:

```
Tool '<name>' has an invalid outputSchema: JSON Schema declares an unsupported
dialect ("$schema": "http://json-schema.org/draft-07/schema#"). The default
validator supports JSON Schema 2020-12 only.
```

The server connects and initializes normally — not one of its 21 tools is usable.
All four `apple-*-mcp` servers are affected identically; this is the
apple-photos-mcp half of the fix. Origin: sweetrb/apple-mail-mcp#147.

## Root cause

The dialect is not chosen at our registration site. `@modelcontextprotocol/sdk`'s
`server/mcp.js` calls

```js
toJsonSchemaCompat(obj, { strictUnions, pipeStrategy })   // <- no `target`
```

and in `sdk/dist/esm/server/zod-json-schema-compat.js`, `mapMiniTarget(undefined)`
resolves to `'draft-7'`. The zod v3 branch then runs `zod-to-json-schema`, whose
default target is draft-07. So **both** the emitted `inputSchema` and
`outputSchema` of every tool are stamped
`"$schema": "http://json-schema.org/draft-07/schema#"` — 42 schemas in this repo.

MCP has since standardized on JSON Schema 2020-12 (SEP-834 / SEP-1613 / SEP-2106),
and clients now reject any other dialect outright rather than attempting to
validate against it.

### A zod v4 upgrade does NOT fix this

Confirmed empirically against **SDK 1.30.0 + zod 4.4.3**: the emitted `$schema` is
*still* draft-07. The SDK's v4 branch (`zod/v4-mini`'s `toJSONSchema`) receives the
same untargeted call and falls back to the same `'draft-7'` mapping. **No zod
migration is attempted here, and one would not help.**

## The fix

Normalize the outgoing payload at the **transport boundary** — the only public
seam that does not reach into SDK internals. New module
`src/utils/jsonSchemaDialect.ts`; `src/index.ts` changes one line:

```diff
-  const transport = new StdioServerTransport();
+  const transport = withJsonSchema2020_12(new StdioServerTransport());
```

`withJsonSchema2020_12()` wraps `transport.send` so every `tools/list` result has
each tool's `inputSchema`/`outputSchema` rewritten to declare
`https://json-schema.org/draft/2020-12/schema`. Every other message — tool-call
results, notifications, errors — is returned untouched, by identity.

The converter also rewrites the keywords whose spelling or meaning changed in
2020-12: `definitions` → `$defs` (and `#/definitions/X` refs → `#/$defs/X`), tuple
`items: [A, B]` → `prefixItems`, `additionalItems` → `items` (tuple only, dropped
otherwise so it can't clobber a non-tuple `items`), `dependencies` →
`dependentRequired` / `dependentSchemas`, and boolean `exclusiveMinimum` /
`exclusiveMaximum` → their numeric 2020-12 form. A nested `$schema` is stripped;
only the root declares a dialect.

**None of those paths is reachable from today's schemas.** The bodies this server
emits are already dialect-portable — no tuple `items`, no `definitions`, no
`dependencies`, no boolean exclusive bounds — so the conversion is provably a
no-op beyond the `$schema` line (see the byte-identical check below). The
converter exists so the seam stays correct if a new zod construct ever introduces
one of those forms.

**No tool definition, zod schema, or handler was changed.**

## Verification

Real MCP handshake (`initialize` → `notifications/initialized` → `tools/list`)
against the **rebuilt committed bundle** in the worktree:

| | before (origin/main bundle) | after (this branch) |
|---|---|---|
| tool count | 21 | **21** (unchanged) |
| `draft-07` occurrences in the payload | 42 | **0** |
| schemas declaring 2020-12 | 0 | **42** (21 tools x 2) |
| `$schema` keys total | 42 | 42 — root-level only, no nested declarations |
| draft-07-only keywords (`definitions` / `additionalItems` / `dependencies`) | 0 | 0 |

Tool-name set identical before and after, and **the schema bodies are
byte-identical once `$schema` is stripped** (40,570 bytes both sides) — confirming
the conversion touches nothing but the dialect declaration on today's schemas.

Gates, all green:

- `pnpm run lint` — clean
- `pnpm run typecheck` — clean
- `pnpm test` — **313 passed** (15 files), including 23 new unit tests for the converter
- `pnpm run format:check` — clean
- `pnpm run test:integration` — 43 passed / 15 skipped, including the two new
  contract assertions in `test/output-schema.test.ts`

## Tests

New `src/utils/jsonSchemaDialect.test.ts` (23 tests) covers the root dialect
stamp, nested `$schema` stripping, `definitions`/`$defs` + `$ref` rewriting, a
non-`definitions` `$ref` left alone, tuple `items` → `prefixItems` with
`additionalItems` → `items`, a stray `additionalItems` dropped rather than
clobbering a non-tuple `items`, the `dependencies` split, both boolean-exclusive
collapse and drop cases, `normalizeOutgoingMessage` over a `tools/list` result
(including a tool with no `outputSchema`) plus identity for tool-call results,
notifications and errors, and `withJsonSchema2020_12` returning the same instance
while delegating the normalized message and forwarding `options`.

`test/output-schema.test.ts` — the existing outputSchema contract suite, which
boots the real built server over stdio — gains two assertions: every advertised
schema declares 2020-12, and no advertised schema contains a draft-07-only
construct. The existing checks could not see this class: they inspect schema
*contents*, and a schema can be perfectly shaped while declaring a dialect that
makes the client discard the tool before it is ever called.

## Docs

- **README → Troubleshooting**: new entry for the "unsupported dialect" symptom
  with the exact error text and the fix (upgrade to 2.1.10, restart the host app).
  A user on any earlier version sees this on every tool with no way to connect it
  to a server version.
- **README → Architecture**: states that schemas are advertised as 2020-12 and
  points at the normalizer.
- **CONTRIBUTING.md**: records the wrapper as load-bearing. It is a
  `transport.send` interception with no local caller — exactly the shape a later
  cleanup removes without knowing it makes the whole server unusable.
- Reviewed and unchanged: the README Tool Reference, `CLAUDE.md`, and all five
  `docs/*.md`. This change adds no tool and alters no parameter or result, and
  none of those files stated a schema dialect.

## Release

`2.1.9` → **`2.1.10`**, bumped with `pnpm version patch --no-git-tag-version` from
the repo root (plugin manifests synced; `sync-plugin-version.mjs --check` passes),
CHANGELOG filed under a real `## [2.1.10] - 2026-08-12` heading. The two entries
previously parked under `## [Unreleased]` (the `pnpm/action-setup` + `codeql-action`
pin bump, and the `js-yaml` floor) are **drained** under that heading — this
release publishes everything on main and nothing renames that section later.
`## [Unreleased]` is left present and empty, as `dependabot-rebuild.yml` requires.
